### PR TITLE
Document robots.txt management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+public/robots.txt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Lakeshore Outdoor Services
+
+The static `public/robots.txt` file is intentionally omitted so the `@astrojs/robots` integration can manage the generated rules.


### PR DESCRIPTION
## Summary
- add a `.gitignore` entry to prevent a static `public/robots.txt` from being checked in
- update the README to document that the robots rules are handled by the `@astrojs/robots` integration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28c7abb6c8326aebe87511222cd90