### PR TITLE
Contact + templates + business data (programmatic SEO seed)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,51 @@
+---
+import { business } from "../data/business";
+const address = business.address;
+---
+<footer class="site-footer">
+  <div class="container">
+    <div>
+      <h2>{business.name}</h2>
+      <p>
+        <a href={`tel:${business.phone}`}>{business.phone}</a><br />
+        <a href={`mailto:${business.email}`}>{business.email}</a>
+      </p>
+      <address>
+        {address.street}<br />
+        {address.city}, {address.region} {address.postal}<br />
+        {address.country}
+      </address>
+    </div>
+    <p class="copyright">&copy; {new Date().getFullYear()} {business.name}. All rights reserved.</p>
+  </div>
+</footer>
+
+<style>
+  .site-footer {
+    background: #1b263b;
+    color: #e0e1dd;
+    padding: 2rem 1rem;
+  }
+
+  .container {
+    margin: 0 auto;
+    max-width: 960px;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  a {
+    color: inherit;
+  }
+
+  address {
+    font-style: normal;
+    line-height: 1.5;
+  }
+
+  .copyright {
+    font-size: 0.875rem;
+    opacity: 0.75;
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,71 @@
+---
+import { business } from "../data/business";
+---
+<header class="site-header">
+  <div class="container">
+    <a class="brand" href="/">{business.name}</a>
+    <nav aria-label="Main navigation">
+      <ul>
+        <li><a href="/">Home</a></li>
+        <li><a href="/services/ice-dam-removal/">Services</a></li>
+        <li><a href="/locations/snow-removal-lake-forest/">Locations</a></li>
+        <li><a href="/contact/">Contact</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<style>
+  .site-header {
+    background: #0d1b2a;
+    color: #fff;
+  }
+
+  .container {
+    margin: 0 auto;
+    max-width: 960px;
+    padding: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    justify-content: space-between;
+  }
+
+  .brand {
+    font-weight: 600;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  nav ul {
+    display: flex;
+    gap: 1rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  nav a {
+    color: #e0e1dd;
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  nav a:hover,
+  nav a:focus {
+    color: #fff;
+    text-decoration: underline;
+  }
+
+  @media (max-width: 600px) {
+    .container {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 1rem;
+    }
+
+    nav ul {
+      flex-wrap: wrap;
+    }
+  }
+</style>

--- a/src/components/JsonLd.astro
+++ b/src/components/JsonLd.astro
@@ -1,0 +1,9 @@
+---
+export interface Props {
+  schema: Record<string, unknown>;
+}
+
+const { schema } = Astro.props;
+const json = JSON.stringify(schema, null, 2);
+---
+<script type="application/ld+json">{json}</script>

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -1,0 +1,30 @@
+---
+import { business } from "../data/business";
+
+export interface Props {
+  title: string;
+  description: string;
+  canonical?: string;
+  type?: string;
+  image?: string;
+}
+
+const { title, description, canonical, type = "website", image } = Astro.props;
+const siteUrl = business.site;
+const url = canonical ?? new URL(Astro.url.pathname, siteUrl).toString();
+---
+<Fragment>
+  <title>{title}</title>
+  <meta name="description" content={description} />
+  <link rel="canonical" href={url} />
+  <meta property="og:type" content={type} />
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={description} />
+  <meta property="og:url" content={url} />
+  <meta property="og:site_name" content={business.name} />
+  {image && <meta property="og:image" content={image} />}
+  <meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
+  <meta name="twitter:title" content={title} />
+  <meta name="twitter:description" content={description} />
+  {image && <meta name="twitter:image" content={image} />}
+</Fragment>

--- a/src/data/business.ts
+++ b/src/data/business.ts
@@ -1,0 +1,15 @@
+export const business = {
+  name: "Lakeshore Outdoor Services",
+  phone: "+1-847-555-1234",
+  email: "hello@lakeshoreoutdoor.com",
+  address: {
+    street: "1250 N Green Bay Rd",
+    city: "Lake Forest",
+    region: "IL",
+    postal: "60045",
+    country: "US",
+  },
+  site: "https://lakeshoreoutdoor.com",
+} as const;
+
+export type Business = typeof business;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,4 +1,7 @@
 ---
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+
 const { title } = Astro.props;
 ---
 <!DOCTYPE html>
@@ -6,10 +9,43 @@ const { title } = Astro.props;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    {title && <title>{title}</title>}
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial,
+          "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+        background: #f8fafc;
+        color: #0f172a;
+      }
+
+      main {
+        flex: 1;
+      }
+
+      a {
+        color: #1d4ed8;
+      }
+
+      a:hover,
+      a:focus {
+        color: #1e3a8a;
+      }
+    </style>
   </head>
-  <body>
-    <slot />
+  <body data-page-title={title ?? undefined}>
+    <Header />
+    <main>
+      <slot />
+    </main>
+    <Footer />
   </body>
 </html>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,127 @@
+---
+import Base from "../layouts/Base.astro";
+import SEO from "../components/SEO.astro";
+import JsonLd from "../components/JsonLd.astro";
+import { business } from "../data/business";
+
+const title = "Get a snow quote";
+const description = "Request fast snow removal pricing from Lakeshore Outdoor Services. Call us or send the form to get a tailored estimate.";
+const canonical = new URL(Astro.url.pathname, business.site).toString();
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  name: business.name,
+  telephone: business.phone,
+  email: business.email,
+  url: canonical,
+  description,
+  address: {
+    "@type": "PostalAddress",
+    streetAddress: business.address.street,
+    addressLocality: business.address.city,
+    addressRegion: business.address.region,
+    postalCode: business.address.postal,
+    addressCountry: business.address.country,
+  },
+};
+---
+<Base title={title}>
+  <SEO title={`${title} | ${business.name}`} description={description} canonical={canonical} type="LocalBusiness" />
+  <JsonLd schema={schema} />
+  <section class="contact">
+    <header>
+      <h1>{title}</h1>
+      <p>
+        We respond to most requests within one business day. Call us at
+        <a href={`tel:${business.phone}`}>{business.phone}</a> or share the details below and we'll follow up with a custom snow removal quote.
+      </p>
+    </header>
+    <form action="https://formspree.io/f/placeholder" method="POST" class="form">
+      <input type="hidden" name="_redirect" value={`${business.site}/thank-you/`} />
+      <label>
+        <span>Name</span>
+        <input type="text" name="name" required autocomplete="name" />
+      </label>
+      <label>
+        <span>Phone</span>
+        <input type="tel" name="phone" required autocomplete="tel" />
+      </label>
+      <label>
+        <span>Service address</span>
+        <input type="text" name="address" required autocomplete="street-address" />
+      </label>
+      <label>
+        <span>Project details</span>
+        <textarea name="message" rows="5" required placeholder="Tell us about your property and snow challenges"></textarea>
+      </label>
+      <button type="submit">Request my quote</button>
+    </form>
+  </section>
+</Base>
+
+<style>
+  .contact {
+    margin: 0 auto;
+    max-width: 720px;
+    padding: 3rem 1.5rem;
+    display: grid;
+    gap: 2rem;
+  }
+
+  header h1 {
+    font-size: clamp(2rem, 3vw, 2.5rem);
+    margin-bottom: 0.5rem;
+  }
+
+  header p {
+    font-size: 1.1rem;
+    line-height: 1.7;
+    color: #1f2937;
+  }
+
+  header a {
+    font-weight: 600;
+  }
+
+  .form {
+    display: grid;
+    gap: 1rem;
+  }
+
+  label {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  input,
+  textarea {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    border: 1px solid #cbd5f5;
+    font-size: 1rem;
+    font-family: inherit;
+    background: #fff;
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  button {
+    padding: 0.85rem 1.5rem;
+    border-radius: 999px;
+    border: none;
+    font-size: 1rem;
+    font-weight: 600;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.2s ease;
+  }
+
+  button:hover,
+  button:focus {
+    background: #1d4ed8;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,113 @@
+---
+import Base from "../layouts/Base.astro";
+import SEO from "../components/SEO.astro";
+import JsonLd from "../components/JsonLd.astro";
+import { business } from "../data/business";
+
+const title = `${business.name} | North Shore snow removal`;
+const description = "Premium residential snow removal, ice dam steaming, and winter maintenance for Lake Forest and the North Shore.";
+const canonical = new URL(Astro.url.pathname, business.site).toString();
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "SnowRemovalService",
+  name: business.name,
+  url: canonical,
+  description,
+  areaServed: {
+    "@type": "AdministrativeArea",
+    name: business.address.city,
+  },
+  provider: {
+    "@type": "LocalBusiness",
+    name: business.name,
+    telephone: business.phone,
+    email: business.email,
+    url: business.site,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: business.address.street,
+      addressLocality: business.address.city,
+      addressRegion: business.address.region,
+      postalCode: business.address.postal,
+      addressCountry: business.address.country,
+    },
+  },
+};
+---
+<Base title={title}>
+  <SEO title={title} description={description} canonical={canonical} type="website" />
+  <JsonLd schema={schema} />
+  <section class="hero">
+    <h1>Reliable snow removal for Lake Forest homes</h1>
+    <p>
+      {business.name} keeps driveways, walks, and roofs clear with proactive monitoring, fast dispatch, and detail-focused crews.
+      From seasonal contracts to emergency ice dam steaming, we tailor service around your property.
+    </p>
+    <div class="actions">
+      <a class="primary" href="/contact/">Get a snow quote</a>
+      <a class="secondary" href="/services/ice-dam-removal/">Explore our services</a>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .hero {
+    margin: 0 auto;
+    max-width: 760px;
+    padding: 4rem 1.5rem;
+    display: grid;
+    gap: 1.5rem;
+    text-align: center;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.5rem, 5vw, 3.25rem);
+    margin: 0;
+  }
+
+  .hero p {
+    font-size: 1.2rem;
+    line-height: 1.7;
+    color: #1f2937;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .primary,
+  .secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.75rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .primary {
+    background: #2563eb;
+    color: #fff;
+  }
+
+  .secondary {
+    border: 2px solid #2563eb;
+    color: #1d4ed8;
+    background: transparent;
+  }
+
+  .primary:hover,
+  .primary:focus {
+    background: #1d4ed8;
+  }
+
+  .secondary:hover,
+  .secondary:focus {
+    border-color: #1d4ed8;
+    color: #1e3a8a;
+  }
+</style>

--- a/src/pages/locations/_template.astro
+++ b/src/pages/locations/_template.astro
@@ -1,0 +1,120 @@
+---
+import Base from "../../layouts/Base.astro";
+import SEO from "../../components/SEO.astro";
+import JsonLd from "../../components/JsonLd.astro";
+import { business } from "../../data/business";
+
+export interface Props {
+  title: string;
+  description: string;
+  serviceName: string;
+  city: string;
+  area?: string;
+  internalLinks?: Array<{ href: string; label: string; description?: string }>;
+}
+
+const { title, description, serviceName, city, area, internalLinks = [] } = Astro.props;
+const canonical = new URL(Astro.url.pathname, business.site).toString();
+const locationName = `${city}${area ? `, ${area}` : ""}`;
+const localBusinessSchema = {
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  name: business.name,
+  description,
+  telephone: business.phone,
+  email: business.email,
+  url: canonical,
+  address: {
+    "@type": "PostalAddress",
+    streetAddress: business.address.street,
+    addressLocality: business.address.city,
+    addressRegion: business.address.region,
+    postalCode: business.address.postal,
+    addressCountry: business.address.country,
+  },
+  areaServed: {
+    "@type": "AdministrativeArea",
+    name: locationName,
+  },
+  makesOffer: {
+    "@type": "Offer",
+    itemOffered: {
+      "@type": "Service",
+      name: serviceName,
+      description,
+    },
+  },
+};
+---
+<Base title={title}>
+  <SEO title={title} description={description} canonical={canonical} type="LocalBusiness" />
+  <JsonLd schema={localBusinessSchema} />
+  <article class="content">
+    <header>
+      <p class="eyebrow">Serving {locationName}</p>
+      <h1>{title}</h1>
+      <p class="lead">{description}</p>
+    </header>
+    <slot />
+    {internalLinks.length > 0 && (
+      <section class="internal-links">
+        <h2>Plan your next step</h2>
+        <ul>
+          {internalLinks.map((link) => (
+            <li>
+              <a href={link.href}>{link.label}</a>
+              {link.description && <p>{link.description}</p>}
+            </li>
+          ))}
+        </ul>
+      </section>
+    )}
+  </article>
+</Base>
+
+<style>
+  .content {
+    margin: 0 auto;
+    max-width: 720px;
+    padding: 3rem 1.5rem;
+    display: grid;
+    gap: 2rem;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.875rem;
+    color: #475569;
+    margin: 0;
+  }
+
+  .lead {
+    font-size: 1.125rem;
+    line-height: 1.6;
+    color: #1f2937;
+  }
+
+  .internal-links ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .internal-links li {
+    background: #e2e8f0;
+    padding: 1rem;
+    border-radius: 0.75rem;
+  }
+
+  .internal-links a {
+    font-weight: 600;
+  }
+
+  .internal-links p {
+    margin: 0.5rem 0 0;
+    color: #1f2937;
+  }
+</style>

--- a/src/pages/locations/snow-removal-lake-forest.astro
+++ b/src/pages/locations/snow-removal-lake-forest.astro
@@ -1,0 +1,88 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+
+const page: Props = {
+  title: "Snow removal in Lake Forest, IL",
+  description:
+    "Season-long snow plowing and sidewalk clearing for Lake Forest homes and estates. Stay safe with proactive weather monitoring and on-call crews.",
+  serviceName: "Residential snow removal",
+  city: "Lake Forest",
+  internalLinks: [
+    {
+      href: "/contact/",
+      label: "Request a seasonal snow quote",
+      description: "Lock in priority service for storms before lake-effect snow hits.",
+    },
+    {
+      href: "/services/ice-dam-removal/",
+      label: "Ice dam removal services",
+      description: "Protect your roofline when heavy snow leads to refreezing and leaks.",
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Trusted winter maintenance for the North Shore</h2>
+    <p>
+      Our Lake Forest routes are staffed around-the-clock during snow events. From circular drives to private walks, we tailor the
+      plan to your property and adjust routes in real time as conditions change.
+    </p>
+    <ul>
+      <li>Seasonal contracts with automatic dispatch</li>
+      <li>Handwork on stairs, walks, and patios included</li>
+      <li>Deicing with eco-friendly melting agents</li>
+    </ul>
+  </section>
+  <section class="faq">
+    <h2>Lake Forest snow removal FAQs</h2>
+    <details>
+      <summary>How early do you start plowing?</summary>
+      <p>
+        Crews mobilize before accumulation hits two inches. We monitor NOAA and private weather feeds to pre-salt surfaces when ice is expected.
+      </p>
+    </details>
+    <details>
+      <summary>Can you clear large estate driveways?</summary>
+      <p>
+        Absolutely. Our fleet includes heavy-duty plow trucks and skid steers capable of managing long driveways and motor courts common in Lake Forest.
+      </p>
+    </details>
+    <details>
+      <summary>Do you offer one-time snow pushes?</summary>
+      <p>
+        Yes, one-time pushes are available as schedule allows. Contact us early to reserve a spot during peak storm windows.
+      </p>
+    </details>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  ul {
+    padding-left: 1.25rem;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .faq details {
+    background: #f8fafc;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+  }
+
+  .faq summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .faq p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/services/_template.astro
+++ b/src/pages/services/_template.astro
@@ -1,0 +1,114 @@
+---
+import Base from "../../layouts/Base.astro";
+import SEO from "../../components/SEO.astro";
+import JsonLd from "../../components/JsonLd.astro";
+import { business } from "../../data/business";
+
+export interface Props {
+  title: string;
+  description: string;
+  serviceName: string;
+  city?: string;
+  area?: string;
+  internalLinks?: Array<{ href: string; label: string; description?: string }>;
+}
+
+const { title, description, serviceName, city, area, internalLinks = [] } = Astro.props;
+const canonical = new URL(Astro.url.pathname, business.site).toString();
+const locationName = city ?? area ?? business.address.city;
+const serviceSchema = {
+  "@context": "https://schema.org",
+  "@type": "SnowRemovalService",
+  name: `${serviceName} | ${business.name}`,
+  description,
+  areaServed: locationName,
+  provider: {
+    "@type": "LocalBusiness",
+    name: business.name,
+    telephone: business.phone,
+    email: business.email,
+    url: business.site,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: business.address.street,
+      addressLocality: business.address.city,
+      addressRegion: business.address.region,
+      postalCode: business.address.postal,
+      addressCountry: business.address.country,
+    },
+  },
+  url: canonical,
+};
+---
+<Base title={title}>
+  <SEO title={title} description={description} canonical={canonical} type="service" />
+  <JsonLd schema={serviceSchema} />
+  <article class="content">
+    <header>
+      <p class="eyebrow">{locationName}</p>
+      <h1>{title}</h1>
+      <p class="lead">{description}</p>
+    </header>
+    <slot />
+    {internalLinks.length > 0 && (
+      <section class="internal-links">
+        <h2>Related resources</h2>
+        <ul>
+          {internalLinks.map((link) => (
+            <li>
+              <a href={link.href}>{link.label}</a>
+              {link.description && <p>{link.description}</p>}
+            </li>
+          ))}
+        </ul>
+      </section>
+    )}
+  </article>
+</Base>
+
+<style>
+  .content {
+    margin: 0 auto;
+    max-width: 720px;
+    padding: 3rem 1.5rem;
+    display: grid;
+    gap: 2rem;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.875rem;
+    color: #475569;
+    margin: 0;
+  }
+
+  .lead {
+    font-size: 1.125rem;
+    line-height: 1.6;
+    color: #1f2937;
+  }
+
+  .internal-links ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .internal-links li {
+    background: #e2e8f0;
+    padding: 1rem;
+    border-radius: 0.75rem;
+  }
+
+  .internal-links a {
+    font-weight: 600;
+  }
+
+  .internal-links p {
+    margin: 0.5rem 0 0;
+    color: #1f2937;
+  }
+</style>

--- a/src/pages/services/ice-dam-removal.astro
+++ b/src/pages/services/ice-dam-removal.astro
@@ -1,0 +1,91 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+
+const page: Props = {
+  title: "Lake Forest ice dam removal pros",
+  description:
+    "Stop roof leaks fast with steam-based ice dam removal. Our Lake Forest team clears problem areas without damaging your shingles.",
+  serviceName: "Ice dam removal",
+  city: "Lake Forest",
+  internalLinks: [
+    {
+      href: "/contact/",
+      label: "Book an ice dam assessment",
+      description: "Use our quick form to schedule an on-site visit before the next freeze.",
+    },
+    {
+      href: "/locations/snow-removal-lake-forest/",
+      label: "Snow removal in Lake Forest",
+      description: "See how we keep North Shore driveways and walks clear all winter.",
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Ice dam removal that protects your roof</h2>
+    <p>
+      We use low-pressure steam to melt away ice dams safely. Our specialists arrive with heated hoses, roof access gear,
+      and snow removal tools to prevent refreezing. You get a clean roof edge and dry ceilings within hours.
+    </p>
+    <ul>
+      <li>Rapid-response crews ready for overnight freezes</li>
+      <li>Steam units that break ice without cracking shingles</li>
+      <li>Preventive treatments to keep meltwater flowing</li>
+    </ul>
+  </section>
+  <section class="faq">
+    <h2>Lake Forest ice dam removal FAQs</h2>
+    <details>
+      <summary>How fast can you get to my home?</summary>
+      <p>
+        During peak storms we prioritize active leaks and often arrive the same day. Evening and weekend dispatch is available for
+        North Shore homeowners.
+      </p>
+    </details>
+    <details>
+      <summary>Will steaming damage my shingles?</summary>
+      <p>
+        No. Steam melts the bond between ice and roofing materials without scraping. Our technicians maintain water flow to
+        prevent refreezing on your eaves.
+      </p>
+    </details>
+    <details>
+      <summary>Do you clear snow before treating the ice dam?</summary>
+      <p>
+        Yes. We shovel critical roof sections and downspouts before steaming so runoff has a clear path away from your gutters
+        and fascia.
+      </p>
+    </details>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  ul {
+    padding-left: 1.25rem;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .faq details {
+    background: #f1f5f9;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+  }
+
+  .faq summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .faq p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -1,0 +1,56 @@
+---
+import Base from "../layouts/Base.astro";
+import SEO from "../components/SEO.astro";
+import { business } from "../data/business";
+
+const title = "Thanks for reaching out";
+const description = "We've received your snow service request and will contact you shortly.";
+const canonical = new URL(Astro.url.pathname, business.site).toString();
+---
+<Base title={title}>
+  <SEO title={`${title} | ${business.name}`} description={description} canonical={canonical} />
+  <section class="thank-you">
+    <h1>{title}</h1>
+    <p>
+      A member of the {business.name} team will be in touch soon. If your need is urgent, feel free to call us at
+      <a href={`tel:${business.phone}`}>{business.phone}</a>.
+    </p>
+    <a class="cta" href="/">Back to home</a>
+  </section>
+</Base>
+
+<style>
+  .thank-you {
+    margin: 0 auto;
+    max-width: 640px;
+    padding: 3rem 1.5rem;
+    display: grid;
+    gap: 1.5rem;
+    text-align: center;
+  }
+
+  .thank-you h1 {
+    font-size: clamp(2rem, 4vw, 2.75rem);
+  }
+
+  .thank-you p {
+    font-size: 1.1rem;
+    line-height: 1.6;
+  }
+
+  .cta {
+    display: inline-block;
+    align-self: center;
+    padding: 0.85rem 1.75rem;
+    border-radius: 999px;
+    background: #2563eb;
+    color: #fff;
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .cta:hover,
+  .cta:focus {
+    background: #1d4ed8;
+  }
+</style>


### PR DESCRIPTION
## Summary
- add a centralized business data module and update SEO/json-ld helpers to reuse it
- build shared layout elements plus contact and thank-you pages with a Formspree lead form
- introduce reusable service/location templates and seed initial programmatic SEO pages

## Testing
- not run (project has no package.json or npm scripts)

------
https://chatgpt.com/codex/tasks/task_e_68e28e5777b08326b69ffe0a4f7da2e9