### PR TITLE
Simplify dependency install step in pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,9 +19,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - name: Install dependencies
-        run: |
-          if [ -f package-lock.json ]; then npm ci; else npm i; fi
+      - run: npm ci || npm install
       - name: Build
         run: npx astro build
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- replace the custom install step with a concise npm install command in the Pages workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e29b3e098c8326bd53791bb56c2333