### PR TITLE
Update service-area business data and coverage content

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,34 +1,30 @@
 ---
-import { business } from "../data/business";
+import { BUSINESS } from "../data/business";
+import { formatPhoneForDisplay } from "../utils/phone";
 
-const { address } = business;
-const hasStreet = address.street.trim().length > 0;
-const hasPostal = address.postal.trim().length > 0;
-const locationLine = [address.city, address.region, hasPostal ? address.postal : null]
-  .filter(Boolean)
-  .join(" ");
+const { address, areasServed } = BUSINESS;
+const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
+const primaryLocation = `${address.city}, ${address.region} • ${address.country}`;
+const featuredAreas = areasServed.slice(0, 6);
 ---
 <footer class="site-footer">
   <div class="container">
     <div>
-      <h2>{business.name}</h2>
+      <h2>{BUSINESS.name}</h2>
       <p>
-        <a href={`tel:${business.phone}`}>{business.phoneDisplay}</a><br />
-        <a href={`mailto:${business.email}`}>{business.email}</a>
-      </p>
-      <address>
-        {hasStreet && (
-          <>
-            {address.street}
-            <br />
-          </>
-        )}
-        {locationLine}
+        <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a>
         <br />
-        {address.country}
-      </address>
+        <a href={`mailto:${BUSINESS.email}`}>{BUSINESS.email}</a>
+      </p>
+      <p class="location">{primaryLocation}</p>
+      <p class="service-areas">
+        <span>Serving:</span>
+        <span class="area-list">{featuredAreas.join(", ")}</span>
+        <span aria-hidden="true">•</span>
+        <a href="/locations/" class="view-all">View all areas</a>
+      </p>
     </div>
-    <p class="copyright">&copy; {new Date().getFullYear()} {business.name}. All rights reserved.</p>
+    <p class="copyright">&copy; {new Date().getFullYear()} {BUSINESS.name}. All rights reserved.</p>
   </div>
 </footer>
 
@@ -51,9 +47,40 @@ const locationLine = [address.city, address.region, hasPostal ? address.postal :
     color: inherit;
   }
 
-  address {
-    font-style: normal;
-    line-height: 1.5;
+  .location {
+    margin: 0;
+    font-weight: 600;
+  }
+
+  .service-areas {
+    margin: 0.5rem 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+  }
+
+  .service-areas span {
+    font-weight: 600;
+  }
+
+  .service-areas .area-list {
+    font-weight: 400;
+  }
+
+  .service-areas span[aria-hidden="true"] {
+    font-weight: 400;
+  }
+
+  .view-all {
+    text-decoration: none;
+    font-weight: 600;
+    color: #cbd5f5;
+  }
+
+  .view-all:hover,
+  .view-all:focus {
+    text-decoration: underline;
   }
 
   .copyright {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,28 +1,30 @@
 ---
-import { business } from "../data/business";
+import { BUSINESS } from "../data/business";
+import { formatPhoneForDisplay } from "../utils/phone";
 
-const { address } = business;
+const { address } = BUSINESS;
 const locationLabel = [address.city, address.region].filter(Boolean).join(", ");
+const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
 ---
 <header class="site-header">
   <div class="top-bar">
     <div class="container">
       <p class="service-area">Serving {locationLabel}</p>
       <div class="contact-links">
-        <a class="contact-link" href={`tel:${business.phone}`}>
+        <a class="contact-link" href={`tel:${BUSINESS.phone}`}>
           <span class="label">Call</span>
-          <span>{business.phoneDisplay}</span>
+          <span>{phoneDisplay}</span>
         </a>
-        <a class="contact-link" href={`mailto:${business.email}`}>
+        <a class="contact-link" href={`mailto:${BUSINESS.email}`}>
           <span class="label">Email</span>
-          <span>{business.email}</span>
+          <span>{BUSINESS.email}</span>
         </a>
       </div>
     </div>
   </div>
   <div class="main-bar">
     <div class="container">
-      <a class="brand" href="/">{business.name}</a>
+      <a class="brand" href="/">{BUSINESS.name}</a>
       <nav aria-label="Main navigation">
         <ul>
           <li><a href="/">Home</a></li>
@@ -31,7 +33,7 @@ const locationLabel = [address.city, address.region].filter(Boolean).join(", ");
           <li><a href="/contact/">Contact</a></li>
         </ul>
       </nav>
-      <a class="cta" href={`tel:${business.phone}`}>Call {business.phoneDisplay}</a>
+      <a class="cta" href={`tel:${BUSINESS.phone}`}>Call {phoneDisplay}</a>
     </div>
   </div>
 </header>

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -1,5 +1,5 @@
 ---
-import { business } from "../data/business";
+import { BUSINESS } from "../data/business";
 
 export interface Props {
   title: string;
@@ -10,7 +10,7 @@ export interface Props {
 }
 
 const { title, description, canonical, type = "website", image } = Astro.props;
-const siteUrl = business.site;
+const siteUrl = BUSINESS.site;
 const url = canonical ?? new URL(Astro.url.pathname, siteUrl).toString();
 ---
 <Fragment>
@@ -21,7 +21,7 @@ const url = canonical ?? new URL(Astro.url.pathname, siteUrl).toString();
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
   <meta property="og:url" content={url} />
-  <meta property="og:site_name" content={business.name} />
+  <meta property="og:site_name" content={BUSINESS.name} />
   {image && <meta property="og:image" content={image} />}
   <meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
   <meta name="twitter:title" content={title} />

--- a/src/data/business.ts
+++ b/src/data/business.ts
@@ -1,18 +1,27 @@
-export const business = {
+export const BUSINESS = {
   name: "Lakeshore Outdoor Services",
-  phone: "+17732366224",
-  phoneDisplay: "(773) 236-6224",
+  phone: "+1-773-236-6224",
   email: "lakeshoreoutdoorteam@gmail.com",
-  // We’ll operate as a service-area business on the site until we confirm a street address.
+  site: "https://lakeshoreoutdoor.com",
+  // service-area business => no street address
   address: {
-    street: "",
     city: "Chicago",
     region: "IL",
-    postal: "",
     country: "US",
   },
-  site: "https://lakeshoreoutdoor.com",
-  serviceAreas: ["Chicago", "Lake County", "North Shore", "Northwest Suburbs"],
+  areasServed: [
+    "Hyde Park",
+    "South Shore",
+    "Bronzeville",
+    "Roseland",
+    "Pullman",
+    "Altgeld Gardens",
+    "Lakeview",
+    "Lincoln Park",
+    "Evanston",
+    "Wilmette",
+    "Winnetka",
+  ],
 } as const;
 
-export type Business = typeof business;
+export type Business = typeof BUSINESS;

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -2,57 +2,46 @@
 import Base from "../layouts/Base.astro";
 import SEO from "../components/SEO.astro";
 import JsonLd from "../components/JsonLd.astro";
-import { business } from "../data/business";
+import { BUSINESS } from "../data/business";
+import { formatPhoneForDisplay } from "../utils/phone";
 
 const title = "Get a snow quote";
-const description = "Request fast snow removal pricing from Lakeshore Outdoor Services. Call us or send the form to get a tailored estimate.";
-const canonical = new URL(Astro.url.pathname, business.site).toString();
-const { address, serviceAreas } = business;
-const hasStreet = address.street.trim().length > 0;
-const hasPostal = address.postal.trim().length > 0;
-const businessAddress = hasStreet
-  ? {
-      "@type": "PostalAddress",
-      streetAddress: address.street,
-      addressLocality: address.city,
-      addressRegion: address.region,
-      ...(hasPostal ? { postalCode: address.postal } : {}),
-      addressCountry: address.country,
-    }
-  : {
-      "@type": "PostalAddress",
-      addressLocality: address.city,
-      addressRegion: address.region,
-      addressCountry: address.country,
-    };
+const description =
+  "Request fast snow removal pricing from Lakeshore Outdoor Services. Call us or send the form to get a tailored estimate.";
+const canonical = new URL(Astro.url.pathname, BUSINESS.site).toString();
+const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
+const businessAddress = {
+  "@type": "PostalAddress",
+  addressLocality: BUSINESS.address.city,
+  addressRegion: BUSINESS.address.region,
+  addressCountry: BUSINESS.address.country,
+};
 
 const schema: Record<string, unknown> = {
   "@context": "https://schema.org",
-  "@type": "LocalBusiness",
-  "@id": `${business.site}/#business`,
-  name: business.name,
-  telephone: business.phone,
-  email: business.email,
+  "@type": ["LocalBusiness", "ServiceAreaBusiness"],
+  "@id": `${BUSINESS.site}/#business`,
+  name: BUSINESS.name,
+  telephone: BUSINESS.phone,
+  email: BUSINESS.email,
   url: canonical,
   description,
   address: businessAddress,
+  areaServed: BUSINESS.areasServed,
   sameAs: [],
 };
-
-if (!hasStreet) {
-  schema.areaServed = serviceAreas;
-}
 ---
 <Base title={title}>
-  <SEO title={`${title} | ${business.name}`} description={description} canonical={canonical} type="LocalBusiness" />
+  <SEO title={`${title} | ${BUSINESS.name}`} description={description} canonical={canonical} type="LocalBusiness" />
   <JsonLd schema={schema} />
   <section class="contact">
     <header>
       <h1>{title}</h1>
       <p>
-        We respond to most requests within one business day. Call us at
-        <a href={`tel:${business.phone}`}>{business.phoneDisplay}</a> or share the details below and we'll follow up with a custom
-        snow removal quote.
+        We’re a Chicago-based service-area business serving Hyde Park, South Shore, Bronzeville, Roseland, Pullman, Altgeld
+        Gardens, Lakeview, Lincoln Park, Evanston, Wilmette, and Winnetka. Call us at
+        <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> or share the details below and we'll follow up with a custom snow
+        removal quote.
       </p>
     </header>
     <form action="https://formspree.io/f/your-form-id" method="POST" class="form">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,83 +2,104 @@
 import Base from "../layouts/Base.astro";
 import SEO from "../components/SEO.astro";
 import JsonLd from "../components/JsonLd.astro";
-import { business } from "../data/business";
+import { BUSINESS } from "../data/business";
+import { formatPhoneForDisplay } from "../utils/phone";
 
-const title = `${business.name} | Chicagoland snow removal`;
-const description = "Reliable residential and light commercial snow removal, de-icing, and winter maintenance across Chicagoland.";
-const canonical = new URL(Astro.url.pathname, business.site).toString();
-const { address, serviceAreas } = business;
-const hasStreet = address.street.trim().length > 0;
-const hasPostal = address.postal.trim().length > 0;
-const businessAddress = hasStreet
-  ? {
-      "@type": "PostalAddress",
-      streetAddress: address.street,
-      addressLocality: address.city,
-      addressRegion: address.region,
-      ...(hasPostal ? { postalCode: address.postal } : {}),
-      addressCountry: address.country,
-    }
-  : {
-      "@type": "PostalAddress",
-      addressLocality: address.city,
-      addressRegion: address.region,
-      addressCountry: address.country,
-    };
+const title = `${BUSINESS.name} | Chicago snow removal crews`;
+const description =
+  "Chicago-based snow removal pros serving Hyde Park, South Shore, Bronzeville, Lakeview, Lincoln Park, Evanston, and nearby neighborhoods.";
+const canonical = new URL(Astro.url.pathname, BUSINESS.site).toString();
+const { address, areasServed } = BUSINESS;
+const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
+const businessAddress = {
+  "@type": "PostalAddress",
+  addressLocality: address.city,
+  addressRegion: address.region,
+  addressCountry: address.country,
+};
 
 const schema: Record<string, unknown> = {
   "@context": "https://schema.org",
-  "@type": "LocalBusiness",
-  "@id": "https://lakeshoreoutdoor.com/#business",
-  name: business.name,
+  "@type": ["LocalBusiness", "ServiceAreaBusiness"],
+  "@id": `${BUSINESS.site}/#business`,
+  name: BUSINESS.name,
   description,
   url: canonical,
-  telephone: business.phone,
-  email: business.email,
+  telephone: BUSINESS.phone,
+  email: BUSINESS.email,
   address: businessAddress,
-  areaServed: serviceAreas,
+  areaServed: areasServed,
   sameAs: [],
 };
-// TODO: Add GBP and Facebook profile URLs to sameAs once available.
+
+const displayAreas = areasServed;
 ---
 <Base title={title}>
   <SEO title={title} description={description} canonical={canonical} type="website" />
   <JsonLd schema={schema} />
   <section class="hero">
-    <h1>Reliable snow removal for Chicagoland homes &amp; small businesses</h1>
+    <h1>Snow removal for Chicago’s south and north lakefront communities</h1>
     <p>
-      {business.name} keeps driveways, sidewalks, and entryways clear with proactive storm monitoring, fast dispatch, and
-      detail-focused crews. From seasonal contracts to emergency response, we tailor service around each property and keep you
-      moving all winter long.
+      {BUSINESS.name} is a Chicago-based service-area business. We keep driveways, sidewalks, alleys, and storefront entries
+      clear across Hyde Park, South Shore, Bronzeville, Lakeview, Lincoln Park, Evanston, and the neighboring communities
+      listed below. Crews monitor winter storms 24/7 and coordinate with you before, during, and after each visit.
     </p>
     <div class="actions">
-      <a class="primary" href="/contact/">Get a snow quote</a>
-      <a class="secondary" href="/services/">Explore our services</a>
+      <a class="primary" href="/contact/">Request a quote</a>
+      <a class="secondary" href={`tel:${BUSINESS.phone}`}>Call {phoneDisplay}</a>
     </div>
-    <a class="call-now" href={`tel:${business.phone}`}>Call {business.phoneDisplay}</a>
+    <div class="quick-links">
+      <a href="/services/snow-removal/">Snow removal programs</a>
+      <a href="/services/ice-dam-removal/">Ice dam removal</a>
+      <a href="/services/emergency-snow-removal/">Emergency dispatch</a>
+      <a href="/locations/">View service areas</a>
+      <a href="/locations/snow-removal-chicago/">Chicago crews</a>
+      <a href="/locations/snow-removal-hyde-park/">Hyde Park team</a>
+      <a href="/locations/snow-removal-lakeview/">Lakeview routes</a>
+      <a href="/locations/snow-removal-lincoln-park/">Lincoln Park coverage</a>
+      <a href="/locations/snow-removal-evanston/">Evanston crews</a>
+    </div>
   </section>
   <section class="services">
-    <h2>Winter services built for Chicagoland weather</h2>
+    <h2>Winter services for homes, small businesses, and community properties</h2>
     <p>
-      We handle plowing, shoveling, de-icing, and roof steaming so you can focus on your family or business. Each route includes
-      handwork for walkways and stairs, real-time communication during storms, and post-event cleanup.
+      We handle plowing, shoveling, de-icing, and roof steaming so you can stay focused on family or operations. Every route
+      includes handwork for walkways and stairs, proactive communication, and detailed follow-up after each storm.
     </p>
     <ul>
-      <li>Seasonal residential snow plowing</li>
-      <li>Sidewalk and walkway shoveling</li>
-      <li>De-icing for drives, stoops, and storefronts</li>
-      <li>Ice dam monitoring and steaming</li>
+      <li>Seasonal and per-event snow plowing with flexible trigger depths</li>
+      <li>Sidewalk and stoop shoveling tailored to dense city blocks</li>
+      <li>Calcium chloride, treated salt, and brine options for safe de-icing</li>
+      <li>Steam-based ice dam removal to protect roofs and gutters</li>
     </ul>
   </section>
   <section class="areas">
-    <h2>Areas we cover</h2>
-    <p>We operate as a service-area business covering much of the North Shore and nearby suburbs.</p>
+    <h2>Service-area coverage</h2>
+    <p>
+      We operate without a public storefront and bring mobile crews to each neighborhood we serve. Explore detailed location
+      pages to learn how we support your block.
+    </p>
     <ul>
-      <li><a href="/locations/snow-removal-chicago/">Chicago</a></li>
-      <li><a href="/locations/snow-removal-lakeview/">Lakeview</a></li>
-      <li><a href="/locations/snow-removal-lincoln-park/">Lincoln Park</a></li>
-      <li><a href="/locations/snow-removal-lake-county/">Lake County</a></li>
+      {displayAreas.map((area) => {
+        const slug = area.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+        const hasPage = [
+          "chicago",
+          "hyde-park",
+          "lakeview",
+          "lincoln-park",
+          "evanston",
+        ].includes(slug);
+        const href = hasPage ? `/locations/snow-removal-${slug}/` : "/locations/";
+        return (
+          <li>
+            <a href={href}>{area}</a>
+          </li>
+        );
+      })}
     </ul>
+    <p class="view-more">
+      Looking for another neighborhood? See the full list on our <a href="/locations/">locations page</a>.
+    </p>
   </section>
 </Base>
 
@@ -143,21 +164,25 @@ const schema: Record<string, unknown> = {
     color: #1e3a8a;
   }
 
-  .call-now {
-    display: inline-flex;
-    align-self: center;
+  .quick-links {
+    display: flex;
+    flex-wrap: wrap;
     justify-content: center;
-    padding: 0.75rem 1.5rem;
-    border-radius: 999px;
-    background: #0f172a;
-    color: #fff;
-    text-decoration: none;
-    font-weight: 600;
+    gap: 0.75rem;
   }
 
-  .call-now:hover,
-  .call-now:focus {
-    background: #0b1220;
+  .quick-links a {
+    background: #e2e8f0;
+    padding: 0.5rem 0.9rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+    color: #0f172a;
+  }
+
+  .quick-links a:hover,
+  .quick-links a:focus {
+    background: #cbd5f5;
   }
 
   .services,
@@ -196,5 +221,16 @@ const schema: Record<string, unknown> = {
   .areas a:hover,
   .areas a:focus {
     background: #cbd5f5;
+  }
+
+  .view-more {
+    text-align: center;
+    margin: 0;
+  }
+
+  @media (max-width: 640px) {
+    .hero p {
+      font-size: 1.05rem;
+    }
   }
 </style>

--- a/src/pages/locations/_template.astro
+++ b/src/pages/locations/_template.astro
@@ -2,7 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import SEO from "../../components/SEO.astro";
 import JsonLd from "../../components/JsonLd.astro";
-import { business } from "../../data/business";
+import { BUSINESS } from "../../data/business";
 
 export interface Props {
   title: string;
@@ -14,48 +14,40 @@ export interface Props {
 }
 
 const { title, description, serviceName, city, area, internalLinks = [] } = Astro.props;
-const canonical = new URL(Astro.url.pathname, business.site).toString();
-const locationName = `${city}${area ? `, ${area}` : ""}`;
-const { address, serviceAreas } = business;
-const hasStreet = address.street.trim().length > 0;
-const hasPostal = address.postal.trim().length > 0;
-const businessAddress = hasStreet
-  ? {
-      "@type": "PostalAddress",
-      streetAddress: address.street,
-      addressLocality: address.city,
-      addressRegion: address.region,
-      ...(hasPostal ? { postalCode: address.postal } : {}),
-      addressCountry: address.country,
-    }
-  : {
-      "@type": "PostalAddress",
-      addressLocality: address.city,
-      addressRegion: address.region,
-      addressCountry: address.country,
-    };
+const canonical = new URL(Astro.url.pathname, BUSINESS.site).toString();
+const locationName = area ? `${area}, ${city}` : city;
+const providerAddress = {
+  "@type": "PostalAddress",
+  addressLocality: BUSINESS.address.city,
+  addressRegion: BUSINESS.address.region,
+  addressCountry: BUSINESS.address.country,
+};
 
 const provider = {
-  "@type": "LocalBusiness",
-  "@id": `${business.site}/#business`,
-  name: business.name,
-  telephone: business.phone,
-  email: business.email,
-  url: business.site,
-  address: businessAddress,
-  ...(hasStreet ? {} : { areaServed: serviceAreas }),
+  "@type": ["LocalBusiness", "ServiceAreaBusiness"],
+  "@id": `${BUSINESS.site}/#business`,
+  name: BUSINESS.name,
+  telephone: BUSINESS.phone,
+  email: BUSINESS.email,
+  url: BUSINESS.site,
+  address: providerAddress,
+  areaServed: BUSINESS.areasServed,
 };
 
 const localBusinessSchema = {
   "@context": "https://schema.org",
-  "@type": "SnowRemovalService",
-  name: business.name,
+  "@type": ["SnowRemovalService", "Service"],
+  name: BUSINESS.name,
   description,
-  telephone: business.phone,
-  email: business.email,
+  telephone: BUSINESS.phone,
+  email: BUSINESS.email,
   url: canonical,
-  address: businessAddress,
+  address: providerAddress,
   areaServed: locationName,
+  serviceArea: {
+    "@type": "AdministrativeArea",
+    name: locationName,
+  },
   serviceType: serviceName,
   provider,
 };
@@ -68,13 +60,13 @@ const breadcrumbs = {
       "@type": "ListItem",
       position: 1,
       name: "Home",
-      item: `${business.site}/`,
+      item: `${BUSINESS.site}/`,
     },
     {
       "@type": "ListItem",
       position: 2,
       name: "Locations",
-      item: `${business.site}/locations/`,
+      item: `${BUSINESS.site}/locations/`,
     },
     {
       "@type": "ListItem",

--- a/src/pages/locations/index.astro
+++ b/src/pages/locations/index.astro
@@ -1,47 +1,58 @@
 ---
 import Base from "../../layouts/Base.astro";
 import SEO from "../../components/SEO.astro";
-import { business } from "../../data/business";
+import { BUSINESS } from "../../data/business";
 
 const title = "Snow removal locations";
-const description = "See Lakeshore Outdoor Services coverage across Chicago, Lakeview, Lincoln Park, and Lake County.";
-const canonical = new URL(Astro.url.pathname, business.site).toString();
-const locations = [
-  {
-    href: "/locations/snow-removal-chicago/",
-    name: "Chicago",
-    summary: "North Side and North Shore routes with plowing, shoveling, and de-icing crews.",
-  },
-  {
-    href: "/locations/snow-removal-lakeview/",
-    name: "Lakeview",
-    summary: "Alley, driveway, and sidewalk service tailored to dense residential blocks.",
-  },
-  {
-    href: "/locations/snow-removal-lincoln-park/",
-    name: "Lincoln Park",
-    summary: "Snow clearing for brownstones, condos, and neighborhood retail corridors.",
-  },
-  {
-    href: "/locations/snow-removal-lake-county/",
-    name: "Lake County",
-    summary: "Large estate and HOA service covering the North Shore suburbs.",
-  },
-];
+const description = "See Lakeshore Outdoor Services coverage across Chicago’s lakefront neighborhoods and nearby North Shore communities.";
+const canonical = new URL(Astro.url.pathname, BUSINESS.site).toString();
+const areaPageMap = new Map<string, string>([
+  ["Hyde Park", "/locations/snow-removal-hyde-park/"],
+  ["Lakeview", "/locations/snow-removal-lakeview/"],
+  ["Lincoln Park", "/locations/snow-removal-lincoln-park/"],
+  ["Evanston", "/locations/snow-removal-evanston/"],
+]);
+
+const areaSummaries: Record<string, string> = {
+  "Hyde Park": "University-area homes, institutions, and condo buildings near the lakefront.",
+  "South Shore": "Lakefront residences, condos, and cultural sites needing careful walkway clearing.",
+  "Bronzeville": "Greystones, brownstones, and mixed-use blocks along the Cottage Grove corridor.",
+  "Roseland": "Single-family homes and small businesses along Michigan Avenue and 111th Street.",
+  "Pullman": "Historic rowhomes and industrial campuses requiring reliable snow staging.",
+  "Altgeld Gardens": "Townhome communities and campus-style developments on the Far South Side.",
+  "Lakeview": "Dense North Side blocks with alleys, shared drives, and busy retail corridors.",
+  "Lincoln Park": "Rowhouses, mid-rises, and storefronts along Clark, Halsted, and Armitage.",
+  "Evanston": "North Shore residences, schools, and small businesses near transit and lakefront routes.",
+  "Wilmette": "Residential streets, lakefront estates, and village retail centers.",
+  "Winnetka": "Estate drives, private lanes, and community institutions across the North Shore.",
+};
+
+const areas = BUSINESS.areasServed.map((area) => ({
+  name: area,
+  href: areaPageMap.get(area) ?? null,
+  summary: areaSummaries[area] ?? "",
+}));
 ---
 <Base title={title}>
-  <SEO title={`${title} | ${business.name}`} description={description} canonical={canonical} type="website" />
+  <SEO title={`${title} | ${BUSINESS.name}`} description={description} canonical={canonical} type="website" />
   <section class="listing">
     <header>
       <h1>{title}</h1>
       <p>{description}</p>
+      <p class="note">
+        Looking for our citywide overview? Visit the <a href="/locations/snow-removal-chicago/">Chicago snow removal page</a>.
+      </p>
     </header>
     <ul>
-      {locations.map((location) => (
+      {areas.map((area) => (
         <li>
-          <h2><a href={location.href}>{location.name}</a></h2>
-          <p>{location.summary}</p>
-          <a class="cta" href={location.href}>View location</a>
+          {area.href ? <h2><a href={area.href}>{area.name}</a></h2> : <h2>{area.name}</h2>}
+          {area.summary && <p>{area.summary}</p>}
+          {area.href && (
+            <a class="cta" href={area.href} aria-label={`View snow removal service details for ${area.name}`}>
+              View area details
+            </a>
+          )}
         </li>
       ))}
     </ul>
@@ -51,7 +62,7 @@ const locations = [
 <style>
   .listing {
     margin: 0 auto;
-    max-width: 720px;
+    max-width: 960px;
     padding: 3rem 1.5rem;
     display: grid;
     gap: 2rem;
@@ -63,6 +74,7 @@ const locations = [
     padding: 0;
     display: grid;
     gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   }
 
   li {
@@ -87,5 +99,10 @@ const locations = [
   .cta:hover,
   .cta:focus {
     background: #1d4ed8;
+  }
+
+  .note {
+    margin: 0;
+    font-weight: 600;
   }
 </style>

--- a/src/pages/locations/snow-removal-chicago.astro
+++ b/src/pages/locations/snow-removal-chicago.astro
@@ -3,16 +3,16 @@ import Template from "./_template.astro";
 import type { Props } from "./_template.astro";
 
 const page: Props = {
-  title: "Snow Removal in Chicago — North Side & North Shore Routes",
+  title: "Snow Removal in Chicago — Lakefront Neighborhood Specialists",
   description:
-    "Seasonal snow plowing, shoveling, and de-icing for Chicago homes and storefronts. Stay ahead of lake-effect storms with proactive crews and clear communication.",
+    "Seasonal snow plowing, shoveling, and de-icing for Chicago homes and storefronts in Hyde Park, South Shore, Bronzeville, Lakeview, and Lincoln Park.",
   serviceName: "Residential & light commercial snow removal",
   city: "Chicago",
   internalLinks: [
     {
       href: "/services/snow-removal/",
       label: "Seasonal snow removal plans",
-      description: "See how our team maintains Chicagoland driveways, walks, and entries from November through March.",
+      description: "See how our team maintains Chicago properties from November through March.",
     },
     {
       href: "/contact/",
@@ -26,8 +26,8 @@ const page: Props = {
   <section>
     <h2>Chicago crews ready for every winter pattern</h2>
     <p>
-      From the lakefront to the northwest neighborhoods, we manage routes that account for varying snowfall bands and wind
-      drifts. Our dispatchers monitor radar around the clock and adjust start times as systems approach the city.
+      From Hyde Park to Rogers Park, we manage routes that account for varying snowfall bands and wind drifts. Our dispatchers
+      monitor radar around the clock and adjust start times as systems approach the city.
     </p>
     <ul>
       <li>Plow trucks and skid steers sized for urban driveways and alleys</li>

--- a/src/pages/locations/snow-removal-evanston.astro
+++ b/src/pages/locations/snow-removal-evanston.astro
@@ -1,60 +1,63 @@
 ---
 import Template from "./_template.astro";
 import type { Props } from "./_template.astro";
-import { business } from "../../data/business";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
 
 const page: Props = {
-  title: "Snow Removal in Lake County — Estates, Drives & Walkways",
+  title: "Snow Removal in Evanston — Residential & Small Commercial",
   description:
-    "Comprehensive snow plowing, shoveling, and ice management for Lake County homes and small businesses with long drives or private roads.",
-  serviceName: "Lake County snow removal",
-  city: "Lake County",
+    "Comprehensive snow plowing, shoveling, and ice management for Evanston homes, multifamily buildings, and storefronts.",
+  serviceName: "Evanston snow removal",
+  city: "Evanston",
   internalLinks: [
     {
       href: "/services/snow-removal/",
       label: "Discover our snow removal services",
-      description: "From seasonal contracts to emergency pushes, we cover Chicagoland and the North Shore.",
+      description: "From seasonal contracts to emergency pushes, we cover Chicago and North Shore communities.",
     },
     {
       href: "/contact/",
-      label: "Plan your Lake County route",
+      label: "Plan your Evanston route",
       description: "Tell us about your driveway layout, sidewalks, and special considerations for a custom quote.",
     },
   ],
 };
+
+const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
 ---
 <Template {...page}>
   <section>
-    <h2>Lake County coverage without the wait</h2>
+    <h2>Evanston coverage without the wait</h2>
     <p>
-      Our teams service communities from Highland Park to Libertyville, maintaining large estate drives and neighborhood HOA
-      routes. Dispatchers adjust timing for lake-effect bands and keep you updated when plows are en route.
+      Our teams service neighborhoods from Main Street to Central Street, maintaining residential driveways, alleys, and
+      commercial walkways. Dispatchers adjust timing for lake-effect bands and keep you updated when plows are en route.
     </p>
     <ul>
-      <li>Heavy-duty trucks and loaders for long drives and cul-de-sacs</li>
-      <li>Shovel crews for patios, walkways, and porch steps</li>
+      <li>Compact trucks and skid steers for tight alleys and parking pads</li>
+      <li>Shovel crews for sidewalks, stoops, and accessible ramps</li>
       <li>Granular and liquid de-icing options based on surface type</li>
     </ul>
   </section>
   <section class="faq">
-    <h2>Lake County FAQs</h2>
+    <h2>Evanston FAQs</h2>
     <details>
       <summary>What snowfall depth triggers service?</summary>
       <p>
         Most seasonal plans trigger at two inches, with pre-salting when freezing rain is in the forecast. We can adjust depth to
-        match HOA bylaws.
+        match village requirements or HOA bylaws.
       </p>
     </details>
     <details>
-      <summary>Can you clear private roads or shared drives?</summary>
+      <summary>Can you clear private alleys or shared drives?</summary>
       <p>
-        Yes. We operate equipment sized for long private drives and shared easements, coordinating with neighbors as needed.
+        Yes. We operate equipment sized for shared easements and coordinate with neighbors as needed to keep everyone moving.
       </p>
     </details>
     <details>
       <summary>How do I request priority support?</summary>
       <p>
-        Call <a href={`tel:${business.phone}`}>{business.phoneDisplay}</a> to reach dispatch directly or submit the
+        Call <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> to reach dispatch directly or submit the
         <a href="/services/emergency-snow-removal/">emergency snow removal form</a> for urgent pushes.
       </p>
     </details>

--- a/src/pages/locations/snow-removal-hyde-park.astro
+++ b/src/pages/locations/snow-removal-hyde-park.astro
@@ -1,0 +1,96 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
+
+const page: Props = {
+  title: "Snow Removal in Hyde Park — Residential & Campus Support",
+  description:
+    "Hyde Park snow plowing, shoveling, and de-icing for historic homes, apartment buildings, and institutional campuses along the lakefront.",
+  serviceName: "Hyde Park snow removal",
+  city: "Chicago",
+  area: "Hyde Park",
+  internalLinks: [
+    {
+      href: "/services/snow-removal/",
+      label: "Seasonal snow removal programs",
+      description: "Learn how we manage Chicago routes with proactive dispatch and detailed follow-up.",
+    },
+    {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency snow removal",
+      description: "Request rapid-response crews when heavy bands stall over the neighborhood.",
+    },
+  ],
+};
+
+const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
+---
+<Template {...page}>
+  <section>
+    <h2>South Side crews dedicated to Hyde Park</h2>
+    <p>
+      From tree-lined streets near the University of Chicago to lakefront high-rises, we tailor equipment and manpower for each
+      property. Dispatchers coordinate timing around parking restrictions and special events to keep access open.
+    </p>
+    <ul>
+      <li>Plowing for alley garages, shared drives, and private lots</li>
+      <li>Hand shoveling for brownstone steps, courtyards, and accessible entrances</li>
+      <li>Pre- and post-storm de-icing to protect concrete, brick, and limestone walkways</li>
+    </ul>
+  </section>
+  <section class="faq">
+    <h2>Hyde Park FAQs</h2>
+    <details>
+      <summary>Do you coordinate with property managers or facility teams?</summary>
+      <p>
+        Yes. We provide updates before, during, and after each storm so property teams can plan staffing, move vehicles, and
+        maintain safe pedestrian paths.
+      </p>
+    </details>
+    <details>
+      <summary>Can you prioritize medical or academic facilities?</summary>
+      <p>
+        Absolutely. Let us know about critical entrances or loading docks so we can stage crews for continuous attention during
+        active weather.
+      </p>
+    </details>
+    <details>
+      <summary>How do I reach dispatch during a storm?</summary>
+      <p>
+        Call <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> for immediate assistance or submit the
+        <a href="/contact/">contact form</a> for non-urgent updates.
+      </p>
+    </details>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  ul {
+    padding-left: 1.25rem;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .faq details {
+    background: #f1f5f9;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+  }
+
+  .faq summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .faq p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/locations/snow-removal-lakeview.astro
+++ b/src/pages/locations/snow-removal-lakeview.astro
@@ -1,7 +1,8 @@
 ---
 import Template from "./_template.astro";
 import type { Props } from "./_template.astro";
-import { business } from "../../data/business";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
 
 const page: Props = {
   title: "Snow Removal in Lakeview, Chicago — Driveways, Sidewalks & De-icing",
@@ -14,7 +15,7 @@ const page: Props = {
     {
       href: "/services/snow-removal/",
       label: "Explore our snow removal programs",
-      description: "Compare seasonal, per-push, and emergency options for Chicagoland properties.",
+      description: "Compare seasonal, per-push, and emergency options for Chicago properties.",
     },
     {
       href: "/contact/",
@@ -23,6 +24,8 @@ const page: Props = {
     },
   ],
 };
+
+const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
 ---
 <Template {...page}>
   <section>
@@ -55,7 +58,7 @@ const page: Props = {
     <details>
       <summary>How do I request emergency service?</summary>
       <p>
-        Call us at <a href={`tel:${business.phone}`}>{business.phoneDisplay}</a> or submit the <a href="/contact/">contact form</a>
+        Call us at <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> or submit the <a href="/contact/">contact form</a>
         to trigger our <a href="/services/emergency-snow-removal/">emergency snow removal team</a>.
       </p>
     </details>

--- a/src/pages/locations/snow-removal-lincoln-park.astro
+++ b/src/pages/locations/snow-removal-lincoln-park.astro
@@ -1,7 +1,8 @@
 ---
 import Template from "./_template.astro";
 import type { Props } from "./_template.astro";
-import { business } from "../../data/business";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
 
 const page: Props = {
   title: "Snow Removal in Lincoln Park — Homes & Storefronts",
@@ -13,7 +14,7 @@ const page: Props = {
   internalLinks: [
     {
       href: "/services/snow-removal/",
-      label: "See Chicagoland snow removal",
+      label: "See Chicago snow removal",
       description: "Learn how we protect North Side properties with proactive monitoring and detailed shovel work.",
     },
     {
@@ -23,6 +24,8 @@ const page: Props = {
     },
   ],
 };
+
+const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
 ---
 <Template {...page}>
   <section>
@@ -56,7 +59,7 @@ const page: Props = {
     <details>
       <summary>Who do I call for urgent service?</summary>
       <p>
-        Reach our dispatch team anytime at <a href={`tel:${business.phone}`}>{business.phoneDisplay}</a> or submit the
+        Reach our dispatch team anytime at <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> or submit the
         <a href="/services/emergency-snow-removal/">emergency snow removal</a> request to jump the line during heavy storms.
       </p>
     </details>

--- a/src/pages/services/_template.astro
+++ b/src/pages/services/_template.astro
@@ -2,7 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import SEO from "../../components/SEO.astro";
 import JsonLd from "../../components/JsonLd.astro";
-import { business } from "../../data/business";
+import { BUSINESS } from "../../data/business";
 
 export interface Props {
   title: string;
@@ -14,46 +14,35 @@ export interface Props {
 }
 
 const { title, description, serviceName, city, area, internalLinks = [] } = Astro.props;
-const canonical = new URL(Astro.url.pathname, business.site).toString();
-const locationName = city ?? area ?? business.address.city;
-const { address, serviceAreas } = business;
-const hasStreet = address.street.trim().length > 0;
-const hasPostal = address.postal.trim().length > 0;
-const providerAddress = hasStreet
-  ? {
-      "@type": "PostalAddress",
-      streetAddress: address.street,
-      addressLocality: address.city,
-      addressRegion: address.region,
-      ...(hasPostal ? { postalCode: address.postal } : {}),
-      addressCountry: address.country,
-    }
-  : {
-      "@type": "PostalAddress",
-      addressLocality: address.city,
-      addressRegion: address.region,
-      addressCountry: address.country,
-    };
-const provider: Record<string, unknown> = {
-  "@type": "LocalBusiness",
-  "@id": `${business.site}/#business`,
-  name: business.name,
-  telephone: business.phone,
-  email: business.email,
-  url: business.site,
-  address: providerAddress,
+const canonical = new URL(Astro.url.pathname, BUSINESS.site).toString();
+const locationName = city ?? area ?? BUSINESS.address.city;
+const providerAddress = {
+  "@type": "PostalAddress",
+  addressLocality: BUSINESS.address.city,
+  addressRegion: BUSINESS.address.region,
+  addressCountry: BUSINESS.address.country,
 };
-
-if (!hasStreet) {
-  provider.areaServed = serviceAreas;
-}
+const provider: Record<string, unknown> = {
+  "@type": ["LocalBusiness", "ServiceAreaBusiness"],
+  "@id": `${BUSINESS.site}/#business`,
+  name: BUSINESS.name,
+  telephone: BUSINESS.phone,
+  email: BUSINESS.email,
+  url: BUSINESS.site,
+  address: providerAddress,
+  areaServed: BUSINESS.areasServed,
+};
 
 const serviceSchema = {
   "@context": "https://schema.org",
-  "@type": "SnowRemovalService",
-  name: `${serviceName} | ${business.name}`,
+  "@type": ["SnowRemovalService", "Service"],
+  name: `${serviceName} | ${BUSINESS.name}`,
   description,
   areaServed: locationName,
+  serviceArea: {
+    "@type": "AdministrativeArea",
+    name: locationName,
+  },
   provider,
   url: canonical,
 };
@@ -66,13 +55,13 @@ const breadcrumbs = {
       "@type": "ListItem",
       position: 1,
       name: "Home",
-      item: `${business.site}/`,
+      item: `${BUSINESS.site}/`,
     },
     {
       "@type": "ListItem",
       position: 2,
       name: "Services",
-      item: `${business.site}/services/`,
+      item: `${BUSINESS.site}/services/`,
     },
     {
       "@type": "ListItem",

--- a/src/pages/services/emergency-snow-removal.astro
+++ b/src/pages/services/emergency-snow-removal.astro
@@ -1,18 +1,19 @@
 ---
 import Template from "./_template.astro";
 import type { Props } from "./_template.astro";
-import { business } from "../../data/business";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
 
 const page: Props = {
   title: "Emergency Snow Removal (24/7 Dispatch) — Lakeshore Outdoor Services",
   description:
-    "Round-the-clock emergency snow plowing and shoveling across Chicagoland. Call anytime to clear surprise drifts or reopen blocked access.",
+    "Round-the-clock emergency snow plowing and shoveling across Chicago neighborhoods including Hyde Park, South Shore, Bronzeville, Lakeview, and Lincoln Park.",
   serviceName: "Emergency snow removal",
   city: "Chicago",
   internalLinks: [
     {
       href: "/services/snow-removal/",
-      label: "Chicagoland snow removal services",
+      label: "Chicago snow removal services",
       description: "See our ongoing programs for seasonal and per-push coverage.",
     },
     {
@@ -22,6 +23,8 @@ const page: Props = {
     },
   ],
 };
+
+const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
 ---
 <Template {...page}>
   <section>
@@ -32,11 +35,11 @@ const page: Props = {
     </p>
     <p>
       Call the emergency snow removal hotline at
-      <a href={`tel:${business.phone}`}>{business.phoneDisplay}</a> to connect directly with dispatch, or tap the button below to
-      send project details.
+      <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> to connect directly with dispatch, or tap the button below to send
+      project details.
     </p>
     <p>
-      <a class="cta" href={`tel:${business.phone}`}>Call {business.phoneDisplay}</a>
+      <a class="cta" href={`tel:${BUSINESS.phone}`}>Call {phoneDisplay}</a>
     </p>
   </section>
   <section class="faq">
@@ -44,7 +47,7 @@ const page: Props = {
     <details>
       <summary>How fast can a crew arrive?</summary>
       <p>
-        We target arrival within 90 minutes inside the city and North Shore, weather and road conditions permitting. We’ll
+        We target arrival within 90 minutes inside the city and lakefront suburbs, weather and road conditions permitting. We’ll
         confirm ETA when you call so you know exactly when help is coming.
       </p>
     </details>
@@ -68,7 +71,8 @@ const page: Props = {
     <p>
       Add yourself to our seasonal roster to secure guaranteed service on the next snowfall. Explore the
       <a href="/services/snow-removal/">snow removal programs</a> or see local coverage in
-      <a href="/locations/snow-removal-lakeview/">Lakeview</a> and <a href="/locations/snow-removal-lincoln-park/">Lincoln Park</a>.
+      <a href="/locations/snow-removal-hyde-park/">Hyde Park</a>, <a href="/locations/snow-removal-lakeview/">Lakeview</a>, and
+      <a href="/locations/snow-removal-lincoln-park/">Lincoln Park</a>.
     </p>
   </section>
 </Template>

--- a/src/pages/services/ice-dam-removal.astro
+++ b/src/pages/services/ice-dam-removal.astro
@@ -3,9 +3,9 @@ import Template from "./_template.astro";
 import type { Props } from "./_template.astro";
 
 const page: Props = {
-  title: "Chicagoland ice dam removal pros",
+  title: "Chicago ice dam removal pros",
   description:
-    "Stop roof leaks fast with steam-based ice dam removal. Our Chicagoland team clears problem areas without damaging your shingles.",
+    "Stop roof leaks fast with steam-based ice dam removal. Our Chicago team clears problem areas for homes in Hyde Park, South Shore, Bronzeville, Lakeview, Lincoln Park, and Evanston.",
   serviceName: "Ice dam removal",
   city: "Chicago",
   internalLinks: [
@@ -41,7 +41,7 @@ const page: Props = {
       <summary>How fast can you get to my home?</summary>
       <p>
         During peak storms we prioritize active leaks and often arrive the same day. Evening and weekend dispatch is available for
-        North Side and North Shore homeowners.
+        South Side and North Side homeowners.
       </p>
     </details>
     <details>

--- a/src/pages/services/index.astro
+++ b/src/pages/services/index.astro
@@ -1,16 +1,17 @@
 ---
 import Base from "../../layouts/Base.astro";
 import SEO from "../../components/SEO.astro";
-import { business } from "../../data/business";
+import { BUSINESS } from "../../data/business";
 
 const title = "Snow and ice services";
-const description = "Browse Lakeshore Outdoor Services offerings for Chicagoland snow plowing, ice dam steaming, and emergency dispatch.";
-const canonical = new URL(Astro.url.pathname, business.site).toString();
+const description =
+  "Browse Lakeshore Outdoor Services offerings for Chicago-area snow plowing, ice dam steaming, and 24/7 emergency dispatch.";
+const canonical = new URL(Astro.url.pathname, BUSINESS.site).toString();
 const services = [
   {
     href: "/services/snow-removal/",
     name: "Snow removal",
-    summary: "Seasonal and per-event plowing, shoveling, and de-icing for homes and small businesses.",
+    summary: "Seasonal and per-event plowing, shoveling, and de-icing for Chicago neighborhoods and nearby lakefront suburbs.",
   },
   {
     href: "/services/emergency-snow-removal/",
@@ -25,11 +26,20 @@ const services = [
 ];
 ---
 <Base title={title}>
-  <SEO title={`${title} | ${business.name}`} description={description} canonical={canonical} type="website" />
+  <SEO title={`${title} | ${BUSINESS.name}`} description={description} canonical={canonical} type="website" />
   <section class="listing">
     <header>
       <h1>{title}</h1>
       <p>{description}</p>
+      <p class="service-areas">Serving Hyde Park, South Shore, Bronzeville, Lakeview, Lincoln Park, Evanston, Wilmette, and more.</p>
+      <p class="locations-note">
+        See location specifics for
+        <a href="/locations/snow-removal-chicago/">Chicago</a>,
+        <a href="/locations/snow-removal-hyde-park/">Hyde Park</a>,
+        <a href="/locations/snow-removal-lakeview/">Lakeview</a>, and
+        <a href="/locations/snow-removal-lincoln-park/">Lincoln Park</a>, or view the
+        <a href="/locations/">full service-area list</a>.
+      </p>
     </header>
     <ul>
       {services.map((service) => (
@@ -82,5 +92,16 @@ const services = [
   .cta:hover,
   .cta:focus {
     background: #1d4ed8;
+  }
+
+  .service-areas {
+    margin: 0;
+    font-weight: 600;
+    color: #1f2937;
+  }
+
+  .locations-note {
+    margin: 0;
+    color: #1f2937;
   }
 </style>

--- a/src/pages/services/snow-removal.astro
+++ b/src/pages/services/snow-removal.astro
@@ -3,16 +3,21 @@ import Template from "./_template.astro";
 import type { Props } from "./_template.astro";
 
 const page: Props = {
-  title: "Chicagoland snow removal services",
+  title: "Chicago snow removal services",
   description:
-    "Residential and light commercial snow plowing, shoveling, and de-icing across Chicago, the North Shore, and nearby suburbs.",
+    "Residential and light commercial snow plowing, shoveling, and de-icing across Hyde Park, South Shore, Bronzeville, Lakeview, Lincoln Park, Evanston, Wilmette, and Winnetka.",
   serviceName: "Snow removal",
   city: "Chicago",
   internalLinks: [
     {
       href: "/locations/snow-removal-chicago/",
       label: "Snow removal in Chicago",
-      description: "See how our city crews handle alleys, sidewalks, and storefronts.",
+      description: "See how our city crews handle alleys, sidewalks, and storefronts across the lakefront neighborhoods.",
+    },
+    {
+      href: "/locations/snow-removal-hyde-park/",
+      label: "Hyde Park snow routes",
+      description: "Explore our coverage for South Side homes, apartment buildings, and institutions.",
     },
     {
       href: "/contact/",
@@ -44,6 +49,10 @@ const page: Props = {
     <p>
       Ask about bundling roof snow clearing or <a href="/services/ice-dam-removal/">ice dam removal</a> with your plan so runoff
       stays controlled even during long freeze-thaw cycles.
+    </p>
+    <p>
+      Unexpected accumulation? Our <a href="/services/emergency-snow-removal/">emergency snow removal team</a> is on call 24/7
+      for rapid response across our Chicago service areas.
     </p>
   </section>
 </Template>

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -1,6 +1,9 @@
 ---
 import Base from "../layouts/Base.astro";
-import { business } from "../data/business";
+import { BUSINESS } from "../data/business";
+import { formatPhoneForDisplay } from "../utils/phone";
+
+const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
 ---
 <Base
   title="Thanks — we got your request"
@@ -12,8 +15,8 @@ import { business } from "../data/business";
   <h1>Thanks! We’ll reach out shortly.</h1>
   <p>
     Our team received your request. If this is urgent, call
-    <a href={`tel:${business.phone}`}>{business.phoneDisplay}</a> or email
-    <a href={`mailto:${business.email}`}>{business.email}</a>.
+    <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> or email
+    <a href={`mailto:${BUSINESS.email}`}>{BUSINESS.email}</a>.
   </p>
   <p><a href="/">Back to home</a></p>
 </Base>

--- a/src/utils/phone.ts
+++ b/src/utils/phone.ts
@@ -1,0 +1,19 @@
+export const formatPhoneForDisplay = (phone: string): string => {
+  const digits = phone.replace(/\D/g, "");
+
+  if (digits.length === 11 && digits.startsWith("1")) {
+    const area = digits.slice(1, 4);
+    const prefix = digits.slice(4, 7);
+    const line = digits.slice(7);
+    return `(${area}) ${prefix}-${line}`;
+  }
+
+  if (digits.length === 10) {
+    const area = digits.slice(0, 3);
+    const prefix = digits.slice(3, 6);
+    const line = digits.slice(6);
+    return `(${area}) ${prefix}-${line}`;
+  }
+
+  return phone;
+};


### PR DESCRIPTION
## Summary
- centralize Lakeshore Outdoor Services contact details and service-area list in `BUSINESS`, and add a shared phone-format utility for consistent tel/mailto presentation.
- refresh header, footer, homepage, contact, and thank-you messaging plus JSON-LD templates to reflect service-area business requirements with city/region-only address data and the official coverage list.
- replace the Lake County location with an Evanston page, add a Hyde Park location page, and expand locations/services content and internal links to highlight the updated Chicago neighborhood coverage.

## Testing
- `npm run build` *(fails: Astro CLI unavailable in this environment after npm registry requests were blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a34602108326b4183c6f9d6351a9