### PR TITLE
Add SEO assets plus new service and location coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-public/robots.txt

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://lakeshoreoutdoor.com/sitemap-index.xml

--- a/src/components/JsonLd.astro
+++ b/src/components/JsonLd.astro
@@ -1,6 +1,6 @@
 ---
 export interface Props {
-  schema: Record<string, unknown>;
+  schema: Record<string, unknown> | Array<unknown>;
 }
 
 const { schema } = Astro.props;

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -12,19 +12,21 @@ export interface Props {
 const { title, description, canonical, type = "website", image } = Astro.props;
 const siteUrl = BUSINESS.site;
 const url = canonical ?? new URL(Astro.url.pathname, siteUrl).toString();
+const brand = BUSINESS.name;
+const formattedTitle = title.includes(brand) ? title : `${title} | ${brand}`;
 ---
 <Fragment>
-  <title>{title}</title>
+  <title>{formattedTitle}</title>
   <meta name="description" content={description} />
   <link rel="canonical" href={url} />
   <meta property="og:type" content={type} />
-  <meta property="og:title" content={title} />
+  <meta property="og:title" content={formattedTitle} />
   <meta property="og:description" content={description} />
   <meta property="og:url" content={url} />
   <meta property="og:site_name" content={BUSINESS.name} />
   {image && <meta property="og:image" content={image} />}
   <meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
-  <meta name="twitter:title" content={title} />
+  <meta name="twitter:title" content={formattedTitle} />
   <meta name="twitter:description" content={description} />
   {image && <meta name="twitter:image" content={image} />}
 </Fragment>

--- a/src/pages/locations/_template.astro
+++ b/src/pages/locations/_template.astro
@@ -4,6 +4,12 @@ import SEO from "../../components/SEO.astro";
 import JsonLd from "../../components/JsonLd.astro";
 import { BUSINESS } from "../../data/business";
 
+type FAQ = {
+  question: string;
+  answer: string;
+  answerHtml?: string;
+};
+
 export interface Props {
   title: string;
   description: string;
@@ -11,11 +17,24 @@ export interface Props {
   city: string;
   area?: string;
   internalLinks?: Array<{ href: string; label: string; description?: string }>;
+  faqs?: FAQ[];
+  faqHeading?: string;
 }
 
-const { title, description, serviceName, city, area, internalLinks = [] } = Astro.props;
+const {
+  title,
+  description,
+  serviceName,
+  city,
+  area,
+  internalLinks = [],
+  faqs = [],
+  faqHeading,
+} = Astro.props;
 const canonical = new URL(Astro.url.pathname, BUSINESS.site).toString();
-const locationName = area ? `${area}, ${city}` : city;
+const schemaLocation = area ?? city;
+const displayLocation = area ? `${area}, ${city}` : city;
+const seoTitle = `${title} | ${BUSINESS.name}`;
 const providerAddress = {
   "@type": "PostalAddress",
   addressLocality: BUSINESS.address.city,
@@ -23,34 +42,50 @@ const providerAddress = {
   addressCountry: BUSINESS.address.country,
 };
 
-const provider = {
+const localBusinessSchema = {
+  "@context": "https://schema.org",
   "@type": ["LocalBusiness", "ServiceAreaBusiness"],
   "@id": `${BUSINESS.site}/#business`,
   name: BUSINESS.name,
   telephone: BUSINESS.phone,
   email: BUSINESS.email,
   url: BUSINESS.site,
+  areaServed: [schemaLocation, ...BUSINESS.areasServed.filter((areaName) => areaName !== schemaLocation)],
   address: providerAddress,
-  areaServed: BUSINESS.areasServed,
 };
 
-const localBusinessSchema = {
+const serviceSchema = {
   "@context": "https://schema.org",
   "@type": ["SnowRemovalService", "Service"],
-  name: BUSINESS.name,
+  name: `${serviceName} in ${schemaLocation} | ${BUSINESS.name}`,
   description,
-  telephone: BUSINESS.phone,
-  email: BUSINESS.email,
-  url: canonical,
-  address: providerAddress,
-  areaServed: locationName,
+  areaServed: schemaLocation,
   serviceArea: {
     "@type": "AdministrativeArea",
-    name: locationName,
+    name: schemaLocation,
+  },
+  provider: {
+    "@id": `${BUSINESS.site}/#business`,
   },
   serviceType: serviceName,
-  provider,
+  url: canonical,
 };
+
+const faqSchema =
+  faqs.length > 0
+    ? {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: faqs.map((faq) => ({
+          "@type": "Question",
+          name: faq.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: faq.answer,
+          },
+        })),
+      }
+    : null;
 
 const breadcrumbs = {
   "@context": "https://schema.org",
@@ -71,23 +106,39 @@ const breadcrumbs = {
     {
       "@type": "ListItem",
       position: 3,
-      name: locationName,
+      name: displayLocation,
       item: canonical,
     },
   ],
 };
+
+const schema = [localBusinessSchema, serviceSchema, ...(faqSchema ? [faqSchema] : []), breadcrumbs];
 ---
-<Base title={title}>
-  <SEO title={title} description={description} canonical={canonical} type="LocalBusiness" />
-  <JsonLd schema={localBusinessSchema} />
-  <JsonLd schema={breadcrumbs} />
+<Base title={seoTitle}>
+  <SEO title={seoTitle} description={description} canonical={canonical} type="LocalBusiness" />
+  <JsonLd schema={schema} />
   <article class="content">
     <header>
-      <p class="eyebrow">Serving {locationName}</p>
+      <p class="eyebrow">Serving {displayLocation}</p>
       <h1>{title}</h1>
       <p class="lead">{description}</p>
     </header>
     <slot />
+    {faqs.length > 0 && (
+      <section class="faq">
+        <h2>{faqHeading ?? `${displayLocation} snow removal FAQs`}</h2>
+        {faqs.map((faq) => (
+          <details>
+            <summary>{faq.question}</summary>
+            {faq.answerHtml ? (
+              <div class="faq-answer" set:html={faq.answerHtml} />
+            ) : (
+              <p class="faq-answer">{faq.answer}</p>
+            )}
+          </details>
+        ))}
+      </section>
+    )}
     {internalLinks.length > 0 && (
       <section class="internal-links">
         <h2>Plan your next step</h2>
@@ -148,5 +199,26 @@ const breadcrumbs = {
   .internal-links p {
     margin: 0.5rem 0 0;
     color: #1f2937;
+  }
+
+  .faq {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .faq details {
+    background: #f1f5f9;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+  }
+
+  .faq summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .faq-answer {
+    margin: 0.75rem 0 0;
+    line-height: 1.6;
   }
 </style>

--- a/src/pages/locations/index.astro
+++ b/src/pages/locations/index.astro
@@ -27,9 +27,16 @@ const breadcrumbs = {
 };
 const areaPageMap = new Map<string, string>([
   ["Hyde Park", "/locations/snow-removal-hyde-park/"],
+  ["South Shore", "/locations/snow-removal-south-shore/"],
+  ["Bronzeville", "/locations/snow-removal-bronzeville/"],
+  ["Roseland", "/locations/snow-removal-roseland/"],
+  ["Pullman", "/locations/snow-removal-pullman/"],
+  ["Altgeld Gardens", "/locations/snow-removal-altgeld-gardens/"],
   ["Lakeview", "/locations/snow-removal-lakeview/"],
   ["Lincoln Park", "/locations/snow-removal-lincoln-park/"],
   ["Evanston", "/locations/snow-removal-evanston/"],
+  ["Wilmette", "/locations/snow-removal-wilmette/"],
+  ["Winnetka", "/locations/snow-removal-winnetka/"],
 ]);
 
 const areaSummaries: Record<string, string> = {

--- a/src/pages/locations/snow-removal-altgeld-gardens.astro
+++ b/src/pages/locations/snow-removal-altgeld-gardens.astro
@@ -1,0 +1,105 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
+
+const page: Props = {
+  title: "Altgeld Gardens snow removal for community campuses",
+  description:
+    "Snow plowing, shoveling, and de-icing for the Altgeld Gardens and Phillip Murray Homes community, including residential courts, schools, and community centers near the Calumet River.",
+  serviceName: "Altgeld Gardens snow removal",
+  city: "Chicago",
+  area: "Altgeld Gardens",
+  internalLinks: [
+    {
+      href: "/services/snow-removal/",
+      label: "Explore snow removal services",
+      description: "See how we manage seasonal, per-event, and emergency coverage for Chicago neighborhoods.",
+    },
+    {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency response",
+      description: "Activate crews when drifting snow blocks cul-de-sacs or community center entrances.",
+    },
+    {
+      href: "/contact/",
+      label: "Request an Altgeld plan",
+      description: "Share court layouts, parking areas, and accessibility needs before the next storm.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Do you maintain shared courts and alleys?",
+      answer:
+        "Yes. We plow residential courts, shared driveways, and alleys connecting to 130th Street and Doty Avenue.",
+    },
+    {
+      question: "Can you support schools and community centers?",
+      answer:
+        "We keep the Childcare Center, library, and schools accessible with clear ramps, loading zones, and bus pick-up areas.",
+    },
+    {
+      question: "How do you manage ice near the Calumet River?",
+      answer:
+        "We monitor temperature swings and use liquid brine plus eco-friendly pellets to prevent refreeze on bridges and riverfront paths.",
+    },
+    {
+      question: "How do residents reach dispatch?",
+      answer:
+        "Call our office or submit the emergency snow removal request if an area needs immediate attention.",
+      answerHtml: `<p>Call our office at <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> or submit the <a href="/services/emergency-snow-removal/">emergency snow removal request</a> if an area needs immediate attention.</p>`,
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Community-focused snow coverage</h2>
+    <p>
+      Altgeld Gardens spans wide residential courts and pedestrian paths that require coordinated snow removal. We map each court
+      to assign the right equipment—compact plows for drive lanes and shovel teams for building entrances and stairwells.
+    </p>
+    <p>
+      Crews also clear key connectors to 130th Street, Stony Island Avenue, and the Bishop Ford Expressway so residents can commute
+      safely during winter storms.
+    </p>
+  </section>
+  <section>
+    <h2>Safe access for services and programs</h2>
+    <p>
+      We maintain access to community anchors including the Altgeld Gardens Library, Childcare Center, and the Carver Park campus.
+      Salting and shoveling schedules are coordinated around food distribution times, after-school programs, and athletic events.
+    </p>
+    <p>
+      Service logs help resident associations document compliance and secure funding for continued winter maintenance.
+    </p>
+  </section>
+  <section>
+    <h2>Monitoring challenging microclimates</h2>
+    <p>
+      The nearby Calumet River and wetlands can create dense fog and slick surfaces. We monitor local sensors and reapply de-icer
+      when freezing rain or river moisture adds a glaze to sidewalks and ramps.
+    </p>
+    <p>
+      Seasonal clients receive updates via text or email, including photos if crews identify drainage issues or snow piles that
+      need relocation.
+    </p>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  p + p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/locations/snow-removal-bronzeville.astro
+++ b/src/pages/locations/snow-removal-bronzeville.astro
@@ -1,0 +1,107 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
+
+const page: Props = {
+  title: "Bronzeville snow removal for historic boulevards",
+  description:
+    "Reliable snow plowing, shoveling, and de-icing for Bronzeville residences, storefronts, and cultural corridors along King Drive, 47th Street, and Oakwood Boulevard.",
+  serviceName: "Bronzeville snow removal",
+  city: "Chicago",
+  area: "Bronzeville",
+  internalLinks: [
+    {
+      href: "/services/snow-removal/",
+      label: "Explore snow removal services",
+      description: "Review our seasonal programs and on-demand pushes for Chicago neighborhoods.",
+    },
+    {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency assistance",
+      description: "Activate 24/7 crews when heavy bands close alleys or storefronts along 47th Street.",
+    },
+    {
+      href: "/contact/",
+      label: "Plan your Bronzeville route",
+      description: "Share property notes so we can prepare for alley access, loading docks, and sidewalk requirements.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Can you protect historic sidewalks and stone steps?",
+      answer:
+        "Yes. We use calcium blends and hand-application techniques on greystone entries along King Drive and Langley Boulevard.",
+    },
+    {
+      question: "Do you coordinate with business corridors?",
+      answer:
+        "We communicate with SSA teams and local chambers to clear curbside parking and bus stops along 43rd and 47th Streets.",
+    },
+    {
+      question: "How quickly can crews return for drifting snow?",
+      answer:
+        "Seasonal customers receive automatic return visits when winds push drifts back across alleys or plaza entrances.",
+    },
+    {
+      question: "What’s the fastest way to reach dispatch?",
+      answer:
+        "Call our office or send an emergency request online if snow piles start blocking traffic or deliveries.",
+      answerHtml: `<p>Call our office at <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> or send an <a href="/services/emergency-snow-removal/">emergency request</a> if snow piles start blocking traffic or deliveries.</p>`,
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Coverage tuned to Bronzeville’s grid</h2>
+    <p>
+      Bronzeville features narrow residential streets, historic greystones, and vibrant commercial corridors. We map alleys and
+      garage entries between Cottage Grove Avenue and State Street to ensure plow trucks and shovel teams arrive without blocking
+      traffic or CTA bus lanes.
+    </p>
+    <p>
+      Crews keep sidewalks open for visitors to the Bronzeville Children’s Museum, Gallery Guichard, and the Harold Washington
+      Cultural Center. We also maintain parking lots for churches and community centers hosting food distribution and weekend
+      programs.
+    </p>
+  </section>
+  <section>
+    <h2>Equipment sized for courtyards and alleys</h2>
+    <p>
+      Many Bronzeville properties rely on gated courtyards and shared driveways. We pair compact plow trucks with walk-behind snow
+      blowers and shovel crews to clear areas that large city plows cannot reach. Crews document each visit with timestamps and
+      before-and-after photos when requested.
+    </p>
+    <p>
+      De-icing materials are tailored to protect the limestone steps and mosaic sidewalks common near historic row homes on
+      Calumet Avenue. For business corridors, we pre-treat crosswalks and curb cuts to keep pedestrian flow moving during
+      neighborhood events and farmers markets.
+    </p>
+  </section>
+  <section>
+    <h2>Storm monitoring and communication</h2>
+    <p>
+      Dispatchers monitor Midway Airport radar, lake-effect advisories, and CTA service alerts. You’ll receive text or email
+      updates when crews depart, along with digital service logs after each pass. If municipal plows redeposit snow at the end of
+      your block, we schedule a return visit to reopen parking and access lanes.
+    </p>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  p + p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/locations/snow-removal-chicago.astro
+++ b/src/pages/locations/snow-removal-chicago.astro
@@ -15,9 +15,31 @@ const page: Props = {
       description: "See how our team maintains Chicago properties from November through March.",
     },
     {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency crews on standby",
+      description: "Request rapid response when blizzards or stuck vehicles halt access.",
+    },
+    {
       href: "/contact/",
       label: "Request a quote",
       description: "Share your property details and we’ll design a route that keeps your site accessible during every storm.",
+    },
+  ],
+  faqs: [
+    {
+      question: "How fast do you dispatch after the snow starts?",
+      answer:
+        "We aim to have crews on-site within two hours of trigger depth, often sooner when heavy accumulation is forecast. For overnight events, routes are staged before dawn to keep morning traffic moving.",
+    },
+    {
+      question: "Can you work with limited parking or tight alleys?",
+      answer:
+        "Yes. Our compact equipment and shovel teams are selected specifically for Chicago’s tighter lots, gangways, and shared drive spaces.",
+    },
+    {
+      question: "Do you offer on-demand pushes for smaller storms?",
+      answer:
+        "We provide one-time service when availability allows. Reach out through our contact form or call us for the fastest response during active weather.",
     },
   ],
 };
@@ -35,30 +57,6 @@ const page: Props = {
       <li>Eco-friendly de-icing blends that protect concrete and landscaping</li>
     </ul>
   </section>
-  <section class="faq">
-    <h2>Chicago snow removal FAQs</h2>
-    <details>
-      <summary>How fast do you dispatch after the snow starts?</summary>
-      <p>
-        We aim to have crews on-site within two hours of trigger depth, often sooner when heavy accumulation is forecast. For
-        overnight events, routes are staged before dawn to keep morning traffic moving.
-      </p>
-    </details>
-    <details>
-      <summary>Can you work with limited parking or tight alleys?</summary>
-      <p>
-        Yes. Our compact equipment and shovel teams are selected specifically for Chicago’s tighter lots, gangways, and shared
-        drive spaces.
-      </p>
-    </details>
-    <details>
-      <summary>Do you offer on-demand pushes for smaller storms?</summary>
-      <p>
-        We provide one-time service when availability allows. Reach out through our <a href="/contact/">contact form</a> or call
-        us for the fastest response during active weather.
-      </p>
-    </details>
-  </section>
 </Template>
 
 <style>
@@ -72,20 +70,5 @@ const page: Props = {
     margin: 0;
     display: grid;
     gap: 0.5rem;
-  }
-
-  .faq details {
-    background: #f8fafc;
-    border-radius: 0.75rem;
-    padding: 1rem 1.25rem;
-  }
-
-  .faq summary {
-    cursor: pointer;
-    font-weight: 600;
-  }
-
-  .faq p {
-    margin-top: 0.75rem;
   }
 </style>

--- a/src/pages/locations/snow-removal-evanston.astro
+++ b/src/pages/locations/snow-removal-evanston.astro
@@ -17,14 +17,35 @@ const page: Props = {
       description: "From seasonal contracts to emergency pushes, we cover Chicago and North Shore communities.",
     },
     {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency response",
+      description: "Secure rapid assistance when heavy snow or ice overwhelms your team.",
+    },
+    {
       href: "/contact/",
       label: "Plan your Evanston route",
       description: "Tell us about your driveway layout, sidewalks, and special considerations for a custom quote.",
     },
   ],
+  faqs: [
+    {
+      question: "What snowfall depth triggers service?",
+      answer:
+        "Most seasonal plans trigger at two inches, with pre-salting when freezing rain is in the forecast. We can adjust depth to match village requirements or HOA bylaws.",
+    },
+    {
+      question: "Can you clear private alleys or shared drives?",
+      answer:
+        "Yes. We operate equipment sized for shared easements and coordinate with neighbors as needed to keep everyone moving.",
+    },
+    {
+      question: "How do I request priority support?",
+      answer:
+        "Call our dispatch team or submit the emergency snow removal form for urgent pushes.",
+      answerHtml: `<p>Call <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> to reach dispatch directly or submit the <a href="/services/emergency-snow-removal/">emergency snow removal form</a> for urgent pushes.</p>`,
+    },
+  ],
 };
-
-const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
 ---
 <Template {...page}>
   <section>
@@ -39,29 +60,6 @@ const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
       <li>Granular and liquid de-icing options based on surface type</li>
     </ul>
   </section>
-  <section class="faq">
-    <h2>Evanston FAQs</h2>
-    <details>
-      <summary>What snowfall depth triggers service?</summary>
-      <p>
-        Most seasonal plans trigger at two inches, with pre-salting when freezing rain is in the forecast. We can adjust depth to
-        match village requirements or HOA bylaws.
-      </p>
-    </details>
-    <details>
-      <summary>Can you clear private alleys or shared drives?</summary>
-      <p>
-        Yes. We operate equipment sized for shared easements and coordinate with neighbors as needed to keep everyone moving.
-      </p>
-    </details>
-    <details>
-      <summary>How do I request priority support?</summary>
-      <p>
-        Call <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> to reach dispatch directly or submit the
-        <a href="/services/emergency-snow-removal/">emergency snow removal form</a> for urgent pushes.
-      </p>
-    </details>
-  </section>
 </Template>
 
 <style>
@@ -75,20 +73,5 @@ const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
     margin: 0;
     display: grid;
     gap: 0.5rem;
-  }
-
-  .faq details {
-    background: #f1f5f9;
-    border-radius: 0.75rem;
-    padding: 1rem 1.25rem;
-  }
-
-  .faq summary {
-    cursor: pointer;
-    font-weight: 600;
-  }
-
-  .faq p {
-    margin-top: 0.75rem;
   }
 </style>

--- a/src/pages/locations/snow-removal-hyde-park.astro
+++ b/src/pages/locations/snow-removal-hyde-park.astro
@@ -22,10 +22,31 @@ const page: Props = {
       label: "Emergency snow removal",
       description: "Request rapid-response crews when heavy bands stall over the neighborhood.",
     },
+    {
+      href: "/contact/",
+      label: "Contact dispatch",
+      description: "Send storm details and photos so we can prioritize your property.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Do you coordinate with property managers or facility teams?",
+      answer:
+        "Yes. We provide updates before, during, and after each storm so property teams can plan staffing, move vehicles, and maintain safe pedestrian paths.",
+    },
+    {
+      question: "Can you prioritize medical or academic facilities?",
+      answer:
+        "Absolutely. Let us know about critical entrances or loading docks so we can stage crews for continuous attention during active weather.",
+    },
+    {
+      question: "How do I reach dispatch during a storm?",
+      answer:
+        "Call our office for immediate assistance or submit the contact form for non-urgent updates.",
+      answerHtml: `<p>Call <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> for immediate assistance or submit the <a href="/contact/">contact form</a> for non-urgent updates.</p>`,
+    },
   ],
 };
-
-const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
 ---
 <Template {...page}>
   <section>
@@ -40,30 +61,6 @@ const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
       <li>Pre- and post-storm de-icing to protect concrete, brick, and limestone walkways</li>
     </ul>
   </section>
-  <section class="faq">
-    <h2>Hyde Park FAQs</h2>
-    <details>
-      <summary>Do you coordinate with property managers or facility teams?</summary>
-      <p>
-        Yes. We provide updates before, during, and after each storm so property teams can plan staffing, move vehicles, and
-        maintain safe pedestrian paths.
-      </p>
-    </details>
-    <details>
-      <summary>Can you prioritize medical or academic facilities?</summary>
-      <p>
-        Absolutely. Let us know about critical entrances or loading docks so we can stage crews for continuous attention during
-        active weather.
-      </p>
-    </details>
-    <details>
-      <summary>How do I reach dispatch during a storm?</summary>
-      <p>
-        Call <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> for immediate assistance or submit the
-        <a href="/contact/">contact form</a> for non-urgent updates.
-      </p>
-    </details>
-  </section>
 </Template>
 
 <style>
@@ -77,20 +74,5 @@ const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
     margin: 0;
     display: grid;
     gap: 0.5rem;
-  }
-
-  .faq details {
-    background: #f1f5f9;
-    border-radius: 0.75rem;
-    padding: 1rem 1.25rem;
-  }
-
-  .faq summary {
-    cursor: pointer;
-    font-weight: 600;
-  }
-
-  .faq p {
-    margin-top: 0.75rem;
   }
 </style>

--- a/src/pages/locations/snow-removal-lakeview.astro
+++ b/src/pages/locations/snow-removal-lakeview.astro
@@ -18,14 +18,35 @@ const page: Props = {
       description: "Compare seasonal, per-push, and emergency options for Chicago properties.",
     },
     {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency response",
+      description: "Call for urgent help when lake-effect bands overwhelm your regular plan.",
+    },
+    {
       href: "/contact/",
       label: "Book Lakeview service",
       description: "Tell us about your building, alley access, and sidewalks so we can assign the right crew.",
     },
   ],
+  faqs: [
+    {
+      question: "Do you clear snow before rush hour?",
+      answer:
+        "Yes. We stage crews overnight so driveways, alleys, and sidewalks are clear before morning commuters hit the road or walk to the train.",
+    },
+    {
+      question: "Can you handle corner lots and long sidewalks?",
+      answer:
+        "Absolutely. Our teams assign extra shovelers to corner buildings to keep crosswalks and curb cuts accessible.",
+    },
+    {
+      question: "How do I request emergency service?",
+      answer:
+        "Call our office or submit the contact form to activate the emergency snow removal team.",
+      answerHtml: `<p>Call us at <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> or submit the <a href="/contact/">contact form</a> to trigger our <a href="/services/emergency-snow-removal/">emergency snow removal team</a>.</p>`,
+    },
+  ],
 };
-
-const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
 ---
 <Template {...page}>
   <section>
@@ -40,29 +61,6 @@ const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
       <li>Calcium chloride and treated salt applications for fast melt</li>
     </ul>
   </section>
-  <section class="faq">
-    <h2>Lakeview service FAQs</h2>
-    <details>
-      <summary>Do you clear snow before rush hour?</summary>
-      <p>
-        Yes. We stage crews overnight so driveways, alleys, and sidewalks are clear before morning commuters hit the road or walk
-        to the train.
-      </p>
-    </details>
-    <details>
-      <summary>Can you handle corner lots and long sidewalks?</summary>
-      <p>
-        Absolutely. Our teams assign extra shovelers to corner buildings to keep crosswalks and curb cuts accessible.
-      </p>
-    </details>
-    <details>
-      <summary>How do I request emergency service?</summary>
-      <p>
-        Call us at <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> or submit the <a href="/contact/">contact form</a>
-        to trigger our <a href="/services/emergency-snow-removal/">emergency snow removal team</a>.
-      </p>
-    </details>
-  </section>
 </Template>
 
 <style>
@@ -76,20 +74,5 @@ const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
     margin: 0;
     display: grid;
     gap: 0.5rem;
-  }
-
-  .faq details {
-    background: #f1f5f9;
-    border-radius: 0.75rem;
-    padding: 1rem 1.25rem;
-  }
-
-  .faq summary {
-    cursor: pointer;
-    font-weight: 600;
-  }
-
-  .faq p {
-    margin-top: 0.75rem;
   }
 </style>

--- a/src/pages/locations/snow-removal-lincoln-park.astro
+++ b/src/pages/locations/snow-removal-lincoln-park.astro
@@ -18,14 +18,36 @@ const page: Props = {
       description: "Learn how we protect North Side properties with proactive monitoring and detailed shovel work.",
     },
     {
+      href: "/services/emergency-snow-removal/",
+      label: "Request emergency help",
+      description: "Activate standby crews when snowdrifts block alleys or storefronts.",
+    },
+    {
       href: "/contact/",
       label: "Schedule a site walk",
       description: "Meet a supervisor to review your parking pads, alleys, and stairways before the next storm.",
     },
   ],
+  faqs: [
+    {
+      question: "Do you coordinate with building managers?",
+      answer:
+        "Yes. We provide storm updates and arrival windows to property managers, ensuring elevators, loading docks, and dumpster pads stay accessible.",
+    },
+    {
+      question: "Can you help with rooftop or deck shoveling?",
+      answer:
+        "We offer rooftop snow clearing when needed to prevent weight buildup and drain blockages. Mention it during your quote request so we can plan extra manpower.",
+      answerHtml: `<p>We offer rooftop snow clearing when needed to prevent weight buildup and drain blockages. Mention it during your <a href="/contact/">quote request</a> so we can plan extra manpower.</p>`,
+    },
+    {
+      question: "Who do I call for urgent service?",
+      answer:
+        "Reach our dispatch team anytime by phone or submit the emergency snow removal request to jump the line during heavy storms.",
+      answerHtml: `<p>Reach our dispatch team anytime at <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> or submit the <a href="/services/emergency-snow-removal/">emergency snow removal</a> request to jump the line during heavy storms.</p>`,
+    },
+  ],
 };
-
-const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
 ---
 <Template {...page}>
   <section>
@@ -40,30 +62,6 @@ const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
       <li>Ice melt applications that balance speed with surface protection</li>
     </ul>
   </section>
-  <section class="faq">
-    <h2>Lincoln Park FAQs</h2>
-    <details>
-      <summary>Do you coordinate with building managers?</summary>
-      <p>
-        Yes. We provide storm updates and arrival windows to property managers, ensuring elevators, loading docks, and dumpster
-        pads stay accessible.
-      </p>
-    </details>
-    <details>
-      <summary>Can you help with rooftop or deck shoveling?</summary>
-      <p>
-        We offer rooftop snow clearing when needed to prevent weight buildup and drain blockages. Let us know during your
-        <a href="/contact/">quote request</a> so we can plan extra manpower.
-      </p>
-    </details>
-    <details>
-      <summary>Who do I call for urgent service?</summary>
-      <p>
-        Reach our dispatch team anytime at <a href={`tel:${BUSINESS.phone}`}>{phoneDisplay}</a> or submit the
-        <a href="/services/emergency-snow-removal/">emergency snow removal</a> request to jump the line during heavy storms.
-      </p>
-    </details>
-  </section>
 </Template>
 
 <style>
@@ -77,20 +75,5 @@ const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
     margin: 0;
     display: grid;
     gap: 0.5rem;
-  }
-
-  .faq details {
-    background: #f8fafc;
-    border-radius: 0.75rem;
-    padding: 1rem 1.25rem;
-  }
-
-  .faq summary {
-    cursor: pointer;
-    font-weight: 600;
-  }
-
-  .faq p {
-    margin-top: 0.75rem;
   }
 </style>

--- a/src/pages/locations/snow-removal-pullman.astro
+++ b/src/pages/locations/snow-removal-pullman.astro
@@ -1,0 +1,102 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
+
+const page: Props = {
+  title: "Pullman snow removal for historic row houses",
+  description:
+    "Snow plowing, shoveling, and de-icing for Pullman’s landmark homes, industrial campuses, and visitor attractions surrounding the Pullman National Historical Park.",
+  serviceName: "Pullman snow removal",
+  city: "Chicago",
+  area: "Pullman",
+  internalLinks: [
+    {
+      href: "/services/snow-removal/",
+      label: "Explore snow removal services",
+      description: "See how our Chicago crews combine plowing, shoveling, and salting for every storm.",
+    },
+    {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency support",
+      description: "Request urgent help when lake-effect bursts bury historic streets or factory lots.",
+    },
+    {
+      href: "/contact/",
+      label: "Schedule a Pullman assessment",
+      description: "Tell us about your row house gangways, factory docks, and visitor entrances before winter hits.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Can you work around landmark landscaping?",
+      answer:
+        "Yes. We protect brick pavers, wrought-iron fencing, and heritage plantings along Arcade Row and the Hotel Florence grounds.",
+    },
+    {
+      question: "Do you maintain visitor parking lots?",
+      answer:
+        "We plow and de-ice museum lots, Metra parking, and tour bus areas so guests can explore the Pullman clock tower complex safely.",
+    },
+    {
+      question: "How do you coordinate with local businesses?",
+      answer:
+        "We schedule plow passes around shift changes for nearby manufacturing campuses and communicate through digital service alerts.",
+    },
+    {
+      question: "What if a storm arrives during an event?",
+      answer:
+        "Call dispatch or submit the emergency form so we can stage crews near the Market Hall or factory courtyard entrances.",
+      answerHtml: `<p>Call dispatch at <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> or submit the <a href="/services/emergency-snow-removal/">emergency form</a> so we can stage crews near the Market Hall or factory courtyard entrances.</p>`,
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Historic streets need careful handling</h2>
+    <p>
+      Pullman’s narrow brick streets and preserved homes require gentle snow removal. We use rubber-edged plows and compact
+      equipment to avoid damaging masonry curbs or ornamental fencing near 111th Street and Cottage Grove Avenue.
+    </p>
+    <p>
+      Shovel teams clear gangways, back entrances, and stoops while applying pet-safe de-icers to protect landscaping. We also
+      keep ADA ramps and boardwalks accessible for museum guests and residents alike.
+    </p>
+  </section>
+  <section>
+    <h2>Industrial and visitor facilities stay open</h2>
+    <p>
+      Beyond the residential core, Pullman includes active factories, distribution centers, and the Method manufacturing campus.
+      We coordinate shift-based plowing to keep docks, loading zones, and employee parking lots clear before and after work hours.
+    </p>
+    <p>
+      Visitor-heavy weekends at the Pullman Visitor Center trigger additional sidewalk patrols and salting around interpretive
+      exhibits, Market Hall vendors, and event spaces.
+    </p>
+  </section>
+  <section>
+    <h2>Proactive communication and reporting</h2>
+    <p>
+      Seasonal clients receive storm alerts, route ETAs, and completion notices via text or email. Service logs document snowfall,
+      materials used, and any concerns we noticed, such as ice buildup near drainage grates or ruts in gravel parking areas.
+    </p>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  p + p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/locations/snow-removal-roseland.astro
+++ b/src/pages/locations/snow-removal-roseland.astro
@@ -1,0 +1,104 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
+
+const page: Props = {
+  title: "Roseland snow removal for residential corridors",
+  description:
+    "Snow plowing, shoveling, and ice control for Roseland’s residential streets, cul-de-sacs, and church campuses along Michigan Avenue, 111th Street, and the Cottage Grove corridor.",
+  serviceName: "Roseland snow removal",
+  city: "Chicago",
+  area: "Roseland",
+  internalLinks: [
+    {
+      href: "/services/snow-removal/",
+      label: "Explore snow removal services",
+      description: "Review our seasonal contracts and per-event coverage for Chicago communities.",
+    },
+    {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency crews",
+      description: "Reach standby teams when drifting snow traps vehicles or closes church lots.",
+    },
+    {
+      href: "/contact/",
+      label: "Schedule a Roseland site visit",
+      description: "Share driveway layouts, alleys, and sidewalk priorities before winter arrives.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Can you manage cul-de-sacs and long driveways?",
+      answer:
+        "Yes. We assign compact plows and skid steers to navigate Roseland’s cul-de-sacs and deeper driveways off Michigan Avenue.",
+    },
+    {
+      question: "Do you work with schools and churches?",
+      answer:
+        "We maintain parking lots and accessible ramps for churches, daycares, and charter schools along 111th Street and King Drive.",
+    },
+    {
+      question: "How do you handle freeze-thaw cycles?",
+      answer:
+        "Our crews return for spot treatments when melting snow refreezes overnight, especially near viaducts and shaded sidewalks.",
+    },
+    {
+      question: "Who should I call if I need extra passes?",
+      answer:
+        "Contact dispatch or submit the emergency form when lake-effect bands rebuild snow piles.",
+      answerHtml: `<p>Contact dispatch at <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> or submit the <a href="/services/emergency-snow-removal/">emergency form</a> when lake-effect bands rebuild snow piles.</p>`,
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Neighborhood routes designed for Roseland</h2>
+    <p>
+      We map every driveway, alley, and sidewalk around Fernwood Park, Palmer Park, and the nearby Pullman National Historical
+      Park. Our crews navigate the one-way residential streets between Wentworth and State, coordinating with residents to move
+      vehicles before storms hit.
+    </p>
+    <p>
+      Shovel teams focus on stoops, gangways, and ADA ramps so seniors, commuters, and students can reach CTA buses and the Metra
+      Electric line without slipping.
+    </p>
+  </section>
+  <section>
+    <h2>Trusted support for community institutions</h2>
+    <p>
+      Roseland’s churches, schools, and social service centers require reliable access during weather emergencies. We stage
+      equipment near 111th Street to keep Sunday services on schedule and ensure food pantry deliveries reach their loading docks.
+    </p>
+    <p>
+      Digital service logs provide timestamps, photos, and material notes so facility managers can document compliance and budget
+      for future seasons.
+    </p>
+  </section>
+  <section>
+    <h2>Continuous monitoring throughout each storm</h2>
+    <p>
+      Dispatchers watch Midway Airport radar, IDOT road sensors, and local alerts to time return visits. When the wind shifts off
+      Lake Michigan and drifts form along Cottage Grove, we deploy additional crews from our South Side yard to reopen lanes and
+      sidewalks quickly.
+    </p>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  p + p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/locations/snow-removal-south-shore.astro
+++ b/src/pages/locations/snow-removal-south-shore.astro
@@ -1,0 +1,112 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
+
+const page: Props = {
+  title: "South Shore snow removal for lakefront blocks",
+  description:
+    "Seasonal and on-demand snow plowing, shoveling, and salting for Chicago’s South Shore neighborhood, covering South Shore Drive, Jeffery Boulevard, and 71st Street corridors.",
+  serviceName: "South Shore snow removal",
+  city: "Chicago",
+  area: "South Shore",
+  internalLinks: [
+    {
+      href: "/services/snow-removal/",
+      label: "Explore snow removal services",
+      description: "See how our programs coordinate plowing, shoveling, and salting across Chicago neighborhoods.",
+    },
+    {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency help",
+      description: "Get rapid support when lake-effect squalls bury driveways or storefronts overnight.",
+    },
+    {
+      href: "/contact/",
+      label: "Request a South Shore quote",
+      description: "Send property details so we can customize a plan before the next band rolls ashore.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Do you service apartment courtyards and co-ops?",
+      answer:
+        "Yes. We tailor crews for gated courtyards, co-op parking lots, and shared walkways common along 73rd and 79th Streets.",
+    },
+    {
+      question: "How do you handle lake-effect icing?",
+      answer:
+        "We monitor shoreline sensors and keep brine trucks staged near South Shore Drive to pre-treat when spray and cold winds create black ice.",
+    },
+    {
+      question: "Can I schedule repeated cleanups during long storms?",
+      answer:
+        "Seasonal clients receive automatic return visits during prolonged systems so entrances stay open for residents and deliveries.",
+    },
+    {
+      question: "Who should I contact for urgent issues?",
+      answer:
+        "Call our dispatch line or submit the emergency snow removal form for immediate assistance.",
+      answerHtml: `<p>Call our dispatch line at <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> or submit the <a href="/services/emergency-snow-removal/">emergency snow removal form</a> for immediate assistance.</p>`,
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Focused coverage for South Shore streets</h2>
+    <p>
+      South Shore’s proximity to Lake Michigan means fast-moving lake-effect bands that drop heavy, wet snow on South Shore Drive,
+      Jeffery Boulevard, and the residential streets feeding the Cultural Center and Rainbow Beach. We map each property to account
+      for one-way traffic patterns, Metra Electric crossings, and school zones near Adam Clayton Powell Jr. Paideia Academy.
+    </p>
+    <p>
+      Crews use compact plow trucks for tight gangways and rear parking pads while shovel teams tackle stoops, walkways, and
+      basement stairwells. De-icing materials are calibrated for historic limestone steps and church entrances along 75th Street
+      to avoid surface damage.
+    </p>
+  </section>
+  <section>
+    <h2>Storm monitoring tailored to the lakefront</h2>
+    <p>
+      We monitor forecasts from the National Weather Service, shoreline temperature buoys, and live feeds from Midway Airport to
+      anticipate sudden shifts in wind direction. When radar shows snow bands redeveloping over the lake, we dispatch additional
+      crews from our Calumet staging yard to cover apartment towers near 71st Street and commercial corridors around Stony Island
+      Avenue.
+    </p>
+    <p>
+      Seasonal contracts include pre-storm brining for long stretches of sidewalk near the South Shore Cultural Center and CPD
+      District 3. After the initial push, supervisors revisit properties to clear municipal windrows and ensure fire hydrants and
+      curb cuts remain visible for emergency vehicles.
+    </p>
+  </section>
+  <section>
+    <h2>Documentation for associations and small businesses</h2>
+    <p>
+      We deliver timestamped service logs after every visit, outlining snow totals, crew arrival and departure times, and the
+      materials applied. Condominium boards along South Bennett Avenue and small business owners on 79th Street rely on those
+      records to prove compliance with Chicago’s sidewalk clearing ordinance.
+    </p>
+    <p>
+      Need flexible billing? We offer seasonal invoices, per-event pricing, and emergency rates so you can protect South Shore
+      residents, congregations, and visitors without surprise costs.
+    </p>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  p + p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/locations/snow-removal-wilmette.astro
+++ b/src/pages/locations/snow-removal-wilmette.astro
@@ -1,0 +1,102 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
+
+const page: Props = {
+  title: "Wilmette snow removal for lakefront suburbs",
+  description:
+    "Professional snow plowing, shoveling, and ice control for Wilmette homes, estates, and downtown storefronts from Sheridan Road to Green Bay Road.",
+  serviceName: "Wilmette snow removal",
+  city: "Wilmette",
+  area: "Wilmette",
+  internalLinks: [
+    {
+      href: "/services/snow-removal/",
+      label: "Explore snow removal services",
+      description: "Learn how we support Chicago and North Shore properties with proactive winter programs.",
+    },
+    {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency snow response",
+      description: "Call when lake-effect squalls or ice storms overwhelm your regular crew.",
+    },
+    {
+      href: "/contact/",
+      label: "Request a Wilmette quote",
+      description: "Send driveway, walkway, and parking details so we can design a seasonal plan.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Do you handle lakefront estates and long driveways?",
+      answer:
+        "Yes. We use truck-mounted plows, loaders, and snow blowers sized for private drives along Sheridan Road and Michigan Avenue.",
+    },
+    {
+      question: "Can you protect bluestone and brick walkways?",
+      answer:
+        "We apply pet-safe calcium blends and hand-shovel delicate surfaces to prevent etching or joint damage.",
+    },
+    {
+      question: "Do you service Metra lots and downtown storefronts?",
+      answer:
+        "We clear commuter parking, alley loading zones, and Central Street storefront sidewalks before the morning rush.",
+    },
+    {
+      question: "How do I reach emergency dispatch?",
+      answer:
+        "Call or submit the emergency snow removal form for immediate support.",
+      answerHtml: `<p>Call <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> or submit the <a href="/services/emergency-snow-removal/">emergency snow removal form</a> for immediate support.</p>`,
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>North Shore crews ready for every storm</h2>
+    <p>
+      Wilmette’s lakefront exposure creates wind-driven snow drifts and icy spray along Sheridan Road and Lake Avenue. We monitor
+      shoreline weather stations to time pre-salting and dispatch crews before morning commutes.
+    </p>
+    <p>
+      Our teams maintain residences, condo associations, and downtown businesses near the Baha’i House of Worship, Gillson Park,
+      and the Village Center.
+    </p>
+  </section>
+  <section>
+    <h2>Tailored equipment for varied properties</h2>
+    <p>
+      We pair truck plows and loaders for large estates with walk-behind blowers and shoveling teams for tight courtyard homes.
+      Heated entry mats, gutters, and drainage points are inspected to prevent refreeze.
+    </p>
+    <p>
+      For commercial properties, we coordinate with property managers to maintain parking lots, alley deliveries, and stairwells
+      leading to offices and restaurants.
+    </p>
+  </section>
+  <section>
+    <h2>Detailed reporting keeps owners informed</h2>
+    <p>
+      After each event, clients receive a digital service log summarizing snowfall totals, start and end times, and materials used.
+      Photos are available on request to document compliance for HOA boards and insurance carriers.
+    </p>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  p + p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/locations/snow-removal-winnetka.astro
+++ b/src/pages/locations/snow-removal-winnetka.astro
@@ -1,0 +1,101 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
+
+const page: Props = {
+  title: "Winnetka snow removal for estate properties",
+  description:
+    "Comprehensive snow plowing, shoveling, and salting for Winnetka estates, village streets, and business districts along Green Bay Road, Elm Street, and Sheridan Road.",
+  serviceName: "Winnetka snow removal",
+  city: "Winnetka",
+  area: "Winnetka",
+  internalLinks: [
+    {
+      href: "/services/snow-removal/",
+      label: "Explore snow removal services",
+      description: "Review our Chicago and North Shore programs for residential, HOA, and commercial clients.",
+    },
+    {
+      href: "/services/emergency-snow-removal/",
+      label: "Emergency response",
+      description: "Call when lake-effect systems or ice storms exceed your regular route capacity.",
+    },
+    {
+      href: "/contact/",
+      label: "Request a Winnetka consultation",
+      description: "Share driveway lengths, private lanes, and walkways so we can tailor equipment and crews.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Do you service private lanes and shared drives?",
+      answer:
+        "Yes. We maintain private lanes throughout Indian Hill, Hubbard Woods, and Sheridan Road enclaves with loaders and compact plows.",
+    },
+    {
+      question: "Can you clear lakefront stairways and terraces?",
+      answer:
+        "We deploy shovel teams with safety harnesses and low-corrosion de-icers to protect stone steps, decks, and lake bluff paths.",
+    },
+    {
+      question: "How do you support downtown businesses?",
+      answer:
+        "We schedule sidewalk shoveling and salting before shoppers arrive on Lincoln Avenue, Elm Street, and Chestnut Street.",
+    },
+    {
+      question: "How can I reach a manager during storms?",
+      answer:
+        "Call dispatch or submit the emergency snow removal form for immediate assistance.",
+      answerHtml: `<p>Call dispatch at <a href="tel:${BUSINESS.phone}">${formatPhoneForDisplay(BUSINESS.phone)}</a> or submit the <a href="/services/emergency-snow-removal/">emergency snow removal form</a> for immediate assistance.</p>`,
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Prepared for Winnetka’s demanding winters</h2>
+    <p>
+      Lakefront winds, tree-lined streets, and long private drives require strategic snow management. We stage crews across the
+      village to respond quickly as storms move inland from Lake Michigan.
+    </p>
+    <p>
+      Seasonal clients rely on us for repeated passes, snow relocation, and documentation needed for HOA boards and estate managers.
+    </p>
+  </section>
+  <section>
+    <h2>Equipment tailored to estate properties</h2>
+    <p>
+      Large estates and private schools benefit from loaders, skid steers, and sidewalk crews that keep garages, service courts,
+      and athletic facilities accessible. We protect heated driveway systems, granite pavers, and decorative lighting from damage.
+    </p>
+    <p>
+      For village streets and commuter parking, we coordinate with municipal schedules to clear curb cuts, train station lots, and
+      pedestrian paths before sunrise.
+    </p>
+  </section>
+  <section>
+    <h2>Communication keeps everyone aligned</h2>
+    <p>
+      Each visit generates a digital report detailing snow totals, materials used, and follow-up recommendations. During extended
+      storms, managers receive ETA updates and photos confirming that entrances, mail kiosks, and fire hydrants remain open.
+    </p>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  p + p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/services/_template.astro
+++ b/src/pages/services/_template.astro
@@ -4,6 +4,12 @@ import SEO from "../../components/SEO.astro";
 import JsonLd from "../../components/JsonLd.astro";
 import { BUSINESS } from "../../data/business";
 
+type FAQ = {
+  question: string;
+  answer: string;
+  answerHtml?: string;
+};
+
 export interface Props {
   title: string;
   description: string;
@@ -11,10 +17,22 @@ export interface Props {
   city?: string;
   area?: string;
   internalLinks?: Array<{ href: string; label: string; description?: string }>;
+  faqs?: FAQ[];
+  faqHeading?: string;
 }
 
-const { title, description, serviceName, city, area, internalLinks = [] } = Astro.props;
+const {
+  title,
+  description,
+  serviceName,
+  city,
+  area,
+  internalLinks = [],
+  faqs = [],
+  faqHeading = `${serviceName} FAQs`,
+} = Astro.props;
 const canonical = new URL(Astro.url.pathname, BUSINESS.site).toString();
+const seoTitle = `${title} | ${BUSINESS.name}`;
 const locationName = city ?? area ?? BUSINESS.address.city;
 const providerAddress = {
   "@type": "PostalAddress",
@@ -22,15 +40,17 @@ const providerAddress = {
   addressRegion: BUSINESS.address.region,
   addressCountry: BUSINESS.address.country,
 };
-const provider: Record<string, unknown> = {
+
+const localBusinessSchema = {
+  "@context": "https://schema.org",
   "@type": ["LocalBusiness", "ServiceAreaBusiness"],
   "@id": `${BUSINESS.site}/#business`,
   name: BUSINESS.name,
   telephone: BUSINESS.phone,
   email: BUSINESS.email,
   url: BUSINESS.site,
-  address: providerAddress,
   areaServed: BUSINESS.areasServed,
+  address: providerAddress,
 };
 
 const serviceSchema = {
@@ -43,9 +63,28 @@ const serviceSchema = {
     "@type": "AdministrativeArea",
     name: locationName,
   },
-  provider,
+  provider: {
+    "@id": `${BUSINESS.site}/#business`,
+  },
+  serviceType: serviceName,
   url: canonical,
 };
+
+const faqSchema =
+  faqs.length > 0
+    ? {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: faqs.map((faq) => ({
+          "@type": "Question",
+          name: faq.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: faq.answer,
+          },
+        })),
+      }
+    : null;
 
 const breadcrumbs = {
   "@context": "https://schema.org",
@@ -71,11 +110,12 @@ const breadcrumbs = {
     },
   ],
 };
+
+const schema = [localBusinessSchema, serviceSchema, ...(faqSchema ? [faqSchema] : []), breadcrumbs];
 ---
-<Base title={title}>
-  <SEO title={title} description={description} canonical={canonical} type="service" />
-  <JsonLd schema={serviceSchema} />
-  <JsonLd schema={breadcrumbs} />
+<Base title={seoTitle}>
+  <SEO title={seoTitle} description={description} canonical={canonical} type="service" />
+  <JsonLd schema={schema} />
   <article class="content">
     <header>
       <p class="eyebrow">{locationName}</p>
@@ -83,9 +123,24 @@ const breadcrumbs = {
       <p class="lead">{description}</p>
     </header>
     <slot />
+    {faqs.length > 0 && (
+      <section class="faq">
+        <h2>{faqHeading}</h2>
+        {faqs.map((faq) => (
+          <details>
+            <summary>{faq.question}</summary>
+            {faq.answerHtml ? (
+              <div class="faq-answer" set:html={faq.answerHtml} />
+            ) : (
+              <p class="faq-answer">{faq.answer}</p>
+            )}
+          </details>
+        ))}
+      </section>
+    )}
     {internalLinks.length > 0 && (
       <section class="internal-links">
-        <h2>Related resources</h2>
+        <h2>Related services</h2>
         <ul>
           {internalLinks.map((link) => (
             <li>
@@ -143,5 +198,26 @@ const breadcrumbs = {
   .internal-links p {
     margin: 0.5rem 0 0;
     color: #1f2937;
+  }
+
+  .faq {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .faq details {
+    background: #f1f5f9;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+  }
+
+  .faq summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .faq-answer {
+    margin: 0.75rem 0 0;
+    line-height: 1.6;
   }
 </style>

--- a/src/pages/services/emergency-snow-removal.astro
+++ b/src/pages/services/emergency-snow-removal.astro
@@ -22,6 +22,23 @@ const page: Props = {
       description: "Send details about your property so we can dispatch the right crew fast.",
     },
   ],
+  faqs: [
+    {
+      question: "How fast can a crew arrive?",
+      answer:
+        "We target arrival within 90 minutes inside the city and lakefront suburbs, weather and road conditions permitting. We’ll confirm ETA when you call so you know exactly when help is coming.",
+    },
+    {
+      question: "What triggers an emergency dispatch?",
+      answer:
+        "Emergencies include blocked driveways, stuck vehicles, disabled equipment, or accumulations beyond your contract’s trigger depth. When totals exceed agreements, we can add an extra pass to reopen access.",
+    },
+    {
+      question: "How is pricing handled?",
+      answer:
+        "Emergency work is billed hourly with a two-hour minimum. We’ll review rates on the phone before dispatching so there are no surprises, and invoice digitally once the job is complete.",
+    },
+  ],
 };
 
 const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
@@ -41,30 +58,6 @@ const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
     <p>
       <a class="cta" href={`tel:${BUSINESS.phone}`}>Call {phoneDisplay}</a>
     </p>
-  </section>
-  <section class="faq">
-    <h2>Emergency snow removal FAQs</h2>
-    <details>
-      <summary>How fast can a crew arrive?</summary>
-      <p>
-        We target arrival within 90 minutes inside the city and lakefront suburbs, weather and road conditions permitting. We’ll
-        confirm ETA when you call so you know exactly when help is coming.
-      </p>
-    </details>
-    <details>
-      <summary>What triggers an emergency dispatch?</summary>
-      <p>
-        Emergencies include blocked driveways, stuck vehicles, disabled equipment, or accumulations beyond your contract’s
-        trigger depth. When totals exceed agreements, we can add an extra pass to reopen access.
-      </p>
-    </details>
-    <details>
-      <summary>How is pricing handled?</summary>
-      <p>
-        Emergency work is billed hourly with a two-hour minimum. We’ll review rates on the phone before dispatching so there are
-        no surprises, and invoice digitally once the job is complete.
-      </p>
-    </details>
   </section>
   <section class="support-links">
     <h2>Stay ahead of the next storm</h2>
@@ -100,18 +93,4 @@ const phoneDisplay = formatPhoneForDisplay(BUSINESS.phone);
     background: #1d4ed8;
   }
 
-  .faq details {
-    background: #f1f5f9;
-    border-radius: 0.75rem;
-    padding: 1rem 1.25rem;
-  }
-
-  .faq summary {
-    cursor: pointer;
-    font-weight: 600;
-  }
-
-  .faq p {
-    margin-top: 0.75rem;
-  }
 </style>

--- a/src/pages/services/ice-dam-removal.astro
+++ b/src/pages/services/ice-dam-removal.astro
@@ -20,6 +20,23 @@ const page: Props = {
       description: "See how we keep city driveways and walks clear before ice dams form.",
     },
   ],
+  faqs: [
+    {
+      question: "How fast can you get to my home?",
+      answer:
+        "During peak storms we prioritize active leaks and often arrive the same day. Evening and weekend dispatch is available for South Side and North Side homeowners.",
+    },
+    {
+      question: "Will steaming damage my shingles?",
+      answer:
+        "No. Steam melts the bond between ice and roofing materials without scraping. Our technicians maintain water flow to prevent refreezing on your eaves.",
+    },
+    {
+      question: "Do you clear snow before treating the ice dam?",
+      answer:
+        "Yes. We shovel critical roof sections and downspouts before steaming so runoff has a clear path away from your gutters and fascia.",
+    },
+  ],
 };
 ---
 <Template {...page}>
@@ -35,30 +52,6 @@ const page: Props = {
       <li>Preventive treatments to keep meltwater flowing</li>
     </ul>
   </section>
-  <section class="faq">
-    <h2>Ice dam removal FAQs</h2>
-    <details>
-      <summary>How fast can you get to my home?</summary>
-      <p>
-        During peak storms we prioritize active leaks and often arrive the same day. Evening and weekend dispatch is available for
-        South Side and North Side homeowners.
-      </p>
-    </details>
-    <details>
-      <summary>Will steaming damage my shingles?</summary>
-      <p>
-        No. Steam melts the bond between ice and roofing materials without scraping. Our technicians maintain water flow to
-        prevent refreezing on your eaves.
-      </p>
-    </details>
-    <details>
-      <summary>Do you clear snow before treating the ice dam?</summary>
-      <p>
-        Yes. We shovel critical roof sections and downspouts before steaming so runoff has a clear path away from your gutters
-        and fascia.
-      </p>
-    </details>
-  </section>
 </Template>
 
 <style>
@@ -72,20 +65,5 @@ const page: Props = {
     margin: 0;
     display: grid;
     gap: 0.5rem;
-  }
-
-  .faq details {
-    background: #f1f5f9;
-    border-radius: 0.75rem;
-    padding: 1rem 1.25rem;
-  }
-
-  .faq summary {
-    cursor: pointer;
-    font-weight: 600;
-  }
-
-  .faq p {
-    margin-top: 0.75rem;
   }
 </style>

--- a/src/pages/services/salting.astro
+++ b/src/pages/services/salting.astro
@@ -1,0 +1,118 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+
+const page: Props = {
+  title: "Chicago salting and de-icing services",
+  description:
+    "Proactive salting and liquid de-icing routes that keep Chicago driveways, walks, and storefronts safe from Hyde Park to the North Shore.",
+  serviceName: "Salting and de-icing",
+  city: "Chicago",
+  internalLinks: [
+    {
+      href: "/services/",
+      label: "All winter services",
+      description: "See how salting pairs with plowing, sidewalk shoveling, and emergency response.",
+    },
+    {
+      href: "/locations/snow-removal-south-shore/",
+      label: "South Shore snow removal",
+      description: "Learn how lake-effect ice is handled along 71st Street and Jeffrey Boulevard.",
+    },
+    {
+      href: "/locations/snow-removal-wilmette/",
+      label: "Wilmette winter coverage",
+      description: "Explore North Shore salting plans tailored to Sheridan Road homes and storefronts.",
+    },
+  ],
+  faqs: [
+    {
+      question: "What ice melt products do you use?",
+      answer:
+        "<p>We stock a range of chlorides, including treated rock salt for roadways and calcium blends for delicate concrete. Crews select materials based on surface type, temperature, and proximity to landscaped beds.</p>",
+    },
+    {
+      question: "Can you pre-treat before a storm?",
+      answer:
+        "<p>Yes. When conditions allow, we apply liquid brine six to twelve hours ahead of snowfall so snow and sleet release easily during the first pass.</p>",
+    },
+    {
+      question: "How do you protect pets and plants?",
+      answer:
+        "<p>We flag sensitive areas during the preseason walkthrough and use pet-safe products or sand where necessary. All materials are applied precisely to avoid overspreading onto turf or shrub beds.</p>",
+    },
+    {
+      question: "Is salting available as a stand-alone service?",
+      answer:
+        "<p>We prioritize bundled clients, but one-time treatments are available when storms create dangerous refreeze conditions. Call dispatch to check availability for your neighborhood.</p>",
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Keep surfaces open during Chicago cold snaps</h2>
+    <p>
+      Lake-effect bursts and Arctic fronts can flash-freeze pavement within minutes. Our de-icing crews patrol city and suburban
+      routes every time pavement temperatures dip toward the teens. We stage salt bins in Hyde Park alleys, load brine tanks near
+      Bronzeville condo corridors, and coordinate with plow teams so each site stays accessible for residents and deliveries.
+    </p>
+    <p>
+      Every route starts with preseason calibration. We document square footage, identify shaded areas prone to black ice, and
+      mark hazards like basement stairwells or retaining walls. When storms hit, that data guides our team so material is spread
+      evenly without damaging masonry or landscaping.
+    </p>
+  </section>
+  <section>
+    <h2>Equipment sized for tight lots and busy corridors</h2>
+    <p>
+      Chicago’s mix of two-flats, courtyard buildings, and historic storefronts demands nimble equipment. Our operators run tailgate
+      spreaders on half-ton trucks for alleys, walk-behind drop spreaders for narrow gangways, and ATV-mounted units for large
+      apartment complexes. Liquid brine rigs sit on dispatch-ready trailers so we can pre-treat arterial routes before the morning
+      commute.
+    </p>
+    <p>
+      On the North Shore, we adapt coverage for brick pavers along Central Street, school campuses near Wilmette Avenue, and
+      lakefront drives exposed to wind-driven spray. Operators document every pass with GPS and send service logs to HOA boards or
+      property managers before sunrise.
+    </p>
+    <p>
+      South Side routes focus on community corridors like Stony Island Avenue and 75th Street. We coordinate with local businesses
+      so sidewalks stay clear for commuters heading to the Metra Electric or CTA Red Line stations.
+    </p>
+  </section>
+  <section>
+    <h2>Season-long monitoring prevents refreeze</h2>
+    <p>
+      Our meteorologists monitor National Weather Service briefings, Midway Airport readings, and shoreline temperature sensors to
+      anticipate freeze-thaw cycles. After a storm, crews return for touch-up applications when meltwater flows back across
+      driveways or when shaded walks along Drexel Boulevard retain slush. We also offer bucketed material for onsite staff so they
+      can treat problem spots between scheduled visits.
+    </p>
+    <p>
+      When temperatures plunge below zero, we switch to magnesium or calcium blends that remain active in extreme cold. These
+      treatments are ideal for elevated entrances at hospitals, schools, and churches that cannot tolerate slick steps during
+      weekend services or early classes.
+    </p>
+    <p>
+      Documentation is delivered after every call-out, including weather notes, product types, and before-and-after photos when
+      requested. These records simplify insurance reporting and demonstrate due diligence for Chicago’s slip-and-fall ordinances.
+    </p>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  p + p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/services/seasonal-contracts.astro
+++ b/src/pages/services/seasonal-contracts.astro
@@ -1,0 +1,119 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+
+const page: Props = {
+  title: "Chicago seasonal snow removal contracts",
+  description:
+    "Lock in season-long snow and ice management with guaranteed dispatch for Chicago neighborhoods and suburbs including South Shore, Roseland, Pullman, Wilmette, and Winnetka.",
+  serviceName: "Seasonal snow contracts",
+  city: "Chicago",
+  internalLinks: [
+    {
+      href: "/services/",
+      label: "All winter services",
+      description: "Bundle contracts with salting, sidewalk shoveling, and emergency call-outs.",
+    },
+    {
+      href: "/locations/snow-removal-roseland/",
+      label: "Roseland snow removal",
+      description: "See how we protect South Side cul-de-sacs, churches, and commercial lots.",
+    },
+    {
+      href: "/locations/snow-removal-winnetka/",
+      label: "Winnetka winter coverage",
+      description: "Explore North Shore programs designed for private drives and estate homes.",
+    },
+  ],
+  faqs: [
+    {
+      question: "What does a seasonal contract include?",
+      answer:
+        "<p>Plans cover automatic dispatch at your trigger depth, plowing, sidewalk shoveling, and standard salting. You receive post-service reports after every storm.</p>",
+    },
+    {
+      question: "Can I customize trigger depths by surface?",
+      answer:
+        "<p>Yes. Many clients choose one-inch triggers for walks and two-inch triggers for driveways or lots. We document preferences during onboarding.</p>",
+    },
+    {
+      question: "How are extreme storms handled?",
+      answer:
+        "<p>When blizzards exceed contracted inches, we keep clearing until your property is accessible. Additional pushes are billed at pre-agreed rates.</p>",
+    },
+    {
+      question: "Do you offer multi-year agreements?",
+      answer:
+        "<p>We provide one-, two-, and three-year contracts with price protections for clients who want long-term planning.</p>",
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Predictable coverage for unpredictable winters</h2>
+    <p>
+      Chicago winters swing from lake-effect dustings to blizzards that shut down Lake Shore Drive. Seasonal contracts guarantee
+      you a crew no matter how the forecast evolves. We map every property before the first flake, identifying snow storage areas,
+      slip hazards, and special requests like priority entrances or loading docks.
+    </p>
+    <p>
+      Contracts span November through April and include preseason site walks, route planning, and onboarding for building staff.
+      Our dispatchers monitor O'Hare and Midway radar, plus shoreline sensors that track lake-effect bands moving into South Shore,
+      Bronzeville, Pullman, and Evanston.
+    </p>
+    <p>
+      Each client receives a custom storm plan showing start times, crew assignments, and escalation contacts. That means property
+      managers and HOA boards know exactly who to call during overnight events.
+    </p>
+  </section>
+  <section>
+    <h2>Flexible triggers and communication</h2>
+    <p>
+      Seasonal programs are designed around your operations. Residential estates in Winnetka might request a one-inch trigger to
+      keep heated driveways spotless, while Roseland churches prioritize accessibility for Sunday services. We can stage sidewalk
+      teams to arrive ahead of plows so parishioners and employees reach entrances safely.
+    </p>
+    <p>
+      Communication is constant: clients receive text or email alerts when storms are imminent, when crews depart, and when service
+      is complete. Digital logs include snow totals, photos, and materials applied. If municipal plows push snow back onto your
+      aprons, we add a return visit without delay.
+    </p>
+    <p>
+      For mixed-use developments, we coordinate with onsite engineers to keep loading docks open and to monitor rooftop drains.
+      Our crews check catch basins, hydrants, and emergency exits to meet Chicago Fire Department compliance rules.
+    </p>
+  </section>
+  <section>
+    <h2>Budget confidence and proactive planning</h2>
+    <p>
+      Seasonal pricing spreads winter costs evenly across monthly invoices, helping condo associations and commercial landlords plan
+      budgets. Multi-year agreements lock in labor and equipment, ensuring the same crew leads return each year. We also reserve
+      backup equipment at our South Side and North Shore yards so we can respond to equipment failures without missing a beat.
+    </p>
+    <p>
+      After winter, we debrief each route, noting opportunities for off-season grading or drainage improvements. Those insights help
+      reduce ice buildup around ADA ramps, trash enclosures, and parking lot entrances before the next snowfall.
+    </p>
+    <p>
+      Ready to secure coverage? Our team can review site plans, past service logs, and compliance notices to build a contract that
+      keeps your Chicago property operating smoothly through the harshest winter stretches.
+    </p>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  p + p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/services/sidewalk-shoveling.astro
+++ b/src/pages/services/sidewalk-shoveling.astro
@@ -1,0 +1,119 @@
+---
+import Template from "./_template.astro";
+import type { Props } from "./_template.astro";
+
+const page: Props = {
+  title: "Chicago sidewalk shoveling crews",
+  description:
+    "Dedicated sidewalk, stair, and entry shoveling teams serving Chicago neighborhoods from Bronzeville and Pullman to Lakeview and Evanston.",
+  serviceName: "Sidewalk shoveling",
+  city: "Chicago",
+  internalLinks: [
+    {
+      href: "/services/",
+      label: "All winter services",
+      description: "Bundle sidewalk labor with plowing, salting, and emergency response.",
+    },
+    {
+      href: "/locations/snow-removal-bronzeville/",
+      label: "Bronzeville snow removal",
+      description: "See how we protect 47th Street businesses and historic greystones.",
+    },
+    {
+      href: "/locations/snow-removal-evanston/",
+      label: "Evanston winter support",
+      description: "Discover shovel plans tailored to campus housing and downtown storefronts.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Do crews clear steps and porches too?",
+      answer:
+        "<p>Yes. We shovel stoops, basement stairs, wheelchair ramps, and loading docks so residents and customers have a safe approach.</p>",
+    },
+    {
+      question: "How early can you arrive?",
+      answer:
+        "<p>Routes begin as early as 3 a.m. so high-traffic sidewalks are clear before breakfast service and school drop-off.</p>",
+    },
+    {
+      question: "Will you shovel during lake-effect bursts?",
+      answer:
+        "<p>We offer return visits when narrow snow bands linger over the South Shore or Rogers Park. Crews cycle back as accumulation rebuilds.</p>",
+    },
+    {
+      question: "Can you help with compliance notices?",
+      answer:
+        "<p>Our service logs include timestamps and photos so you can prove timely clearing to the City of Chicago or neighborhood associations.</p>",
+    },
+  ],
+};
+---
+<Template {...page}>
+  <section>
+    <h2>Hand crews dedicated to people-first pathways</h2>
+    <p>
+      Chicago ordinances require sidewalks cleared within hours of each snowfall. We build shoveling teams specifically for
+      pedestrian areas—school zones, transit stops, senior housing, and storefront corridors. Crews rotate through Bronzeville,
+      South Shore, Pullman, and Hyde Park during heavy events, focusing on corners where plows leave windrows and where residents
+      need extra assistance.
+    </p>
+    <p>
+      Sidewalk leads coordinate with our plow dispatch center so driveways and walks finish simultaneously. That means customers
+      can step from the curb onto a treated surface, and delivery drivers have a direct path to service doors and freight
+      elevators.
+    </p>
+  </section>
+  <section>
+    <h2>Detailed attention for stairs, ramps, and entries</h2>
+    <p>
+      We use ergonomic shovels, snow blowers, and battery-powered brushes sized for Chicago brownstone stoops and limestone steps
+      along Drexel Boulevard. Crews apply ice melt by hand along railings and tuck-in areas so thawing water doesn’t refreeze into
+      slick patches. For busy CTA stations and apartment lobbies, we can stage attendants to maintain mats and mop up slush during
+      peak hours.
+    </p>
+    <p>
+      Our teams also support North Side business districts, clearing patios and multi-tenant entryways along Clark Street, Halsted,
+      and Broadway. In Evanston, we keep University classrooms, research facilities, and student residences accessible even during
+      finals week storms.
+    </p>
+    <p>
+      For Pullman row homes and industrial corridors, we adapt workflows to historic brick sidewalks and loading docks where
+      machinery cannot reach. Sanding is available for pavers or granite surfaces that require extra traction.
+    </p>
+  </section>
+  <section>
+    <h2>Communication that keeps you compliant</h2>
+    <p>
+      Each shoveling event ends with a digital report noting arrival times, weather conditions, and any obstructions we cleared.
+      That documentation helps property managers respond to city inspectors or insurance adjusters. If we spot icy gutter
+      discharge or damaged downspouts, we flag the issue so maintenance teams can intervene before the next storm.
+    </p>
+    <p>
+      We also coordinate with building engineers to manage rooftop melt and basement stair drains. When lake-effect systems stall
+      over the South Side, we deploy extra crews from our Calumet staging area to keep ADA ramps open at schools, churches, and
+      community centers.
+    </p>
+    <p>
+      Seasonal clients receive text alerts when crews are en route and completion notices once surfaces are clear. Need on-demand
+      help after volunteer shovelers fall behind? We offer emergency dispatch during prolonged storms, with crews ready to serve
+      Bronzeville art corridors, Pullman National Historical Park, and the Evanston lakefront.
+    </p>
+  </section>
+</Template>
+
+<style>
+  section {
+    display: grid;
+    gap: 1rem;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  p + p {
+    margin-top: 0.75rem;
+  }
+</style>

--- a/src/pages/services/snow-removal.astro
+++ b/src/pages/services/snow-removal.astro
@@ -25,6 +25,28 @@ const page: Props = {
       description: "Lock in priority dispatch before the next winter storm rolls in.",
     },
   ],
+  faqs: [
+    {
+      question: "What types of properties do you service?",
+      answer:
+        "<p>We focus on residential driveways, small commercial lots, condo associations, and institutions that need consistent service on sidewalks and entries. Our crews adapt equipment to tight South Side alleys and North Shore carriage drives alike.</p>",
+    },
+    {
+      question: "How do you decide when to dispatch crews?",
+      answer:
+        "<p>We monitor multiple weather feeds and send alerts as lake-effect bands build. Routes launch once accumulation hits your chosen trigger depth, typically between one and two inches, with return visits for drifting or refreeze concerns.</p>",
+    },
+    {
+      question: "Can I bundle shoveling and de-icing?",
+      answer:
+        "<p>Yes. Most seasonal plans include sidewalk shoveling teams paired with calibrated salt or calcium treatments. We tailor material blends to concrete age, pet traffic, and environmental goals.</p>",
+    },
+    {
+      question: "Do you offer storm reporting?",
+      answer:
+        "<p>After each visit you receive a timestamped service log detailing start and finish times, crew notes, and photos when requested. These reports keep HOA boards and property managers aligned on winter maintenance.</p>",
+    },
+  ],
 };
 ---
 <Template {...page}>


### PR DESCRIPTION
## Summary
- add robots.txt with the sitemap pointer while keeping the existing CNAME file
- expand the service template/FAQ schema and add salting, sidewalk shoveling, and seasonal contract service pages
- expand the location template/index and add South Shore, Bronzeville, Roseland, Pullman, Altgeld Gardens, Wilmette, and Winnetka coverage pages
- standardize SEO title handling so the brand suffix is applied once everywhere

## Changed Files
- public/robots.txt
- src/components/JsonLd.astro, src/components/SEO.astro
- src/pages/services/_template.astro and related service detail pages
- src/pages/locations/_template.astro, index, and new neighborhood pages

## Checklist
- [x] Added robots.txt sitemap directive without removing the existing CNAME file
- [x] Created salting, sidewalk shoveling, and seasonal contract service pages with internal links, FAQ accordions, and LocalBusiness/Service schema
- [x] Created South Shore, Bronzeville, Roseland, Pullman, Altgeld Gardens, Wilmette, and Winnetka location pages with required content, links, and schema
- [x] Standardized service/location `<title>` output to include “| Lakeshore Outdoor Services”
- [x] Ensured each service/location page emits LocalBusiness, Service, FAQPage, and BreadcrumbList JSON-LD via a single script tag

------
https://chatgpt.com/codex/tasks/task_e_68e2ac22e748832695efb244d43d1481