### PR TITLE
Use SVG hero fallback and document local image workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+src/assets/generated/
+public/img/
+.astro/

--- a/IMAGES.md
+++ b/IMAGES.md
@@ -1,0 +1,71 @@
+# Images
+
+The repository avoids committing binary image assets so the default clone stays lightweight and text-only. When you need to
+test Astro's `<Picture />` pipeline locally, generate temporary placeholders on your machine and keep them out of version
+control.
+
+## Hero placeholder workflow
+
+The home page hero includes a commented example that expects a file at `src/assets/generated/hero-placeholder.png`. Follow the
+steps below to create (and later remove) that file as needed.
+
+1. Create the working directory:
+   ```bash
+   mkdir -p src/assets/generated
+   ```
+2. Choose one of the following approaches to place a lightweight image in that directory:
+   - **Download a placeholder:**
+     ```bash
+     curl "https://dummyimage.com/1200x800/60a5fa/eff6ff.png&text=Snow+Crew" \
+       --output src/assets/generated/hero-placeholder.png
+     ```
+     This produces a ~50–70 KB PNG with a gradient background and text label that is sufficient for development.
+   - **Generate a gradient with Sharp:**
+     ```bash
+     npm install --save-dev sharp
+     node <<'NODE'
+     import sharp from "sharp";
+
+     const width = 1200;
+     const height = 800;
+
+     const gradient = Buffer.from(
+       `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">\n` +
+         '<defs>\n' +
+         '  <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">\n' +
+         '    <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.75"/>\n' +
+         '    <stop offset="100%" stop-color="#1d4ed8" stop-opacity="0.9"/>\n' +
+         '  </linearGradient>\n' +
+         '</defs>\n' +
+         `<rect width="${width}" height="${height}" fill="url(#g)" rx="48"/>\n` +
+         '</svg>'
+     );
+
+     await sharp(gradient)
+       .png({ compressionLevel: 9 })
+       .toFile("src/assets/generated/hero-placeholder.png");
+     NODE
+     ```
+     Remove `sharp` from `devDependencies` after you finish if you installed it solely for generating placeholders.
+
+## Using the placeholder with `<Picture />`
+
+Once the image exists locally, uncomment or adapt the example in `src/pages/index.astro`:
+
+```astro
+import { Picture } from "astro:assets";
+
+<Picture
+  src={Astro.resolve("../assets/generated/hero-placeholder.png")}
+  widths={[480, 768, 1024]}
+  sizes="(max-width: 960px) 100vw, 520px"
+  formats={["avif", "webp", "png"]}
+  alt="Snow removal crew clearing a driveway"
+  class="hero-picture"
+/>
+```
+
+## Clean up before committing
+
+Delete any generated binaries when you're done or keep them ignored under `src/assets/generated/`. The `.gitignore` file is
+configured to skip that folder so placeholders never reach the repository.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../.astro/types.d.ts" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,26 +38,69 @@ const displayAreas = areasServed;
   <SEO title={title} description={description} canonical={canonical} type="website" />
   <JsonLd schema={schema} />
   <section class="hero">
-    <h1>Snow removal for Chicago’s south and north lakefront communities</h1>
-    <p>
-      {BUSINESS.name} is a Chicago-based service-area business. We keep driveways, sidewalks, alleys, and storefront entries
-      clear across Hyde Park, South Shore, Bronzeville, Lakeview, Lincoln Park, Evanston, and the neighboring communities
-      listed below. Crews monitor winter storms 24/7 and coordinate with you before, during, and after each visit.
-    </p>
-    <div class="actions">
-      <a class="primary" href="/contact/">Request a quote</a>
-      <a class="secondary" href={`tel:${BUSINESS.phone}`}>Call {phoneDisplay}</a>
+    <div class="hero-content">
+      <h1>Snow removal for Chicago’s south and north lakefront communities</h1>
+      <p>
+        {BUSINESS.name} is a Chicago-based service-area business. We keep driveways, sidewalks, alleys, and storefront entries
+        clear across Hyde Park, South Shore, Bronzeville, Lakeview, Lincoln Park, Evanston, and the neighboring communities
+        listed below. Crews monitor winter storms 24/7 and coordinate with you before, during, and after each visit.
+      </p>
+      <div class="actions">
+        <a class="primary" href="/contact/">Request a quote</a>
+        <a class="secondary" href={`tel:${BUSINESS.phone}`}>Call {phoneDisplay}</a>
+      </div>
+      <div class="quick-links">
+        <a href="/services/snow-removal/">Snow removal programs</a>
+        <a href="/services/ice-dam-removal/">Ice dam removal</a>
+        <a href="/services/emergency-snow-removal/">Emergency dispatch</a>
+        <a href="/locations/">View service areas</a>
+        <a href="/locations/snow-removal-chicago/">Chicago crews</a>
+        <a href="/locations/snow-removal-hyde-park/">Hyde Park team</a>
+        <a href="/locations/snow-removal-lakeview/">Lakeview routes</a>
+        <a href="/locations/snow-removal-lincoln-park/">Lincoln Park coverage</a>
+        <a href="/locations/snow-removal-evanston/">Evanston crews</a>
+      </div>
     </div>
-    <div class="quick-links">
-      <a href="/services/snow-removal/">Snow removal programs</a>
-      <a href="/services/ice-dam-removal/">Ice dam removal</a>
-      <a href="/services/emergency-snow-removal/">Emergency dispatch</a>
-      <a href="/locations/">View service areas</a>
-      <a href="/locations/snow-removal-chicago/">Chicago crews</a>
-      <a href="/locations/snow-removal-hyde-park/">Hyde Park team</a>
-      <a href="/locations/snow-removal-lakeview/">Lakeview routes</a>
-      <a href="/locations/snow-removal-lincoln-park/">Lincoln Park coverage</a>
-      <a href="/locations/snow-removal-evanston/">Evanston crews</a>
+    <div class="hero-media" aria-hidden="true">
+      <!--
+        Example: replace this SVG with a locally generated asset when testing the responsive image pipeline.
+        <Picture
+          src={Astro.resolve("../assets/generated/hero-placeholder.png")}
+          widths={[480, 768, 1024]}
+          sizes="(max-width: 960px) 100vw, 520px"
+          formats={["avif", "webp", "png"]}
+          alt="Snow removal crew clearing a driveway"
+          class="hero-picture"
+        />
+      -->
+      <svg viewBox="0 0 320 220" role="presentation" focusable="false">
+        <defs>
+          <linearGradient id="heroGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.25" />
+            <stop offset="100%" stop-color="#1d4ed8" stop-opacity="0.65" />
+          </linearGradient>
+        </defs>
+        <rect width="320" height="220" rx="28" fill="url(#heroGradient)" />
+        <g fill="#f8fafc" opacity="0.9">
+          <circle cx="76" cy="72" r="28" />
+          <circle cx="122" cy="98" r="18" />
+          <circle cx="182" cy="70" r="22" />
+        </g>
+        <path
+          d="M32 160c32-28 64-28 96 0s64 28 96 0 64-28 96 0"
+          fill="none"
+          stroke="#dbeafe"
+          stroke-width="12"
+          stroke-linecap="round"
+        />
+        <path
+          d="M40 182c32-18 64-18 96 0s64 18 96 0 64-18 96 0"
+          fill="none"
+          stroke="#eff6ff"
+          stroke-width="10"
+          stroke-linecap="round"
+        />
+      </svg>
     </div>
   </section>
   <section class="services">
@@ -106,22 +149,64 @@ const displayAreas = areasServed;
 <style>
   .hero {
     margin: 0 auto;
-    max-width: 760px;
+    max-width: 1100px;
     padding: 4rem 1.5rem 3rem;
+    display: grid;
+    gap: 2.5rem;
+  }
+
+  .hero-content {
     display: grid;
     gap: 1.5rem;
     text-align: center;
   }
 
-  .hero h1 {
+  .hero-content h1 {
     font-size: clamp(2.5rem, 5vw, 3.25rem);
     margin: 0;
   }
 
-  .hero p {
+  .hero-content p {
     font-size: 1.2rem;
     line-height: 1.7;
     color: #1f2937;
+  }
+
+  .hero-media,
+  .hero-picture {
+    width: min(100%, 520px);
+    margin: 0 auto;
+    border-radius: 1.75rem;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.16);
+  }
+
+  .hero-media {
+    aspect-ratio: 16 / 11;
+    background: linear-gradient(135deg, #dbeafe 10%, #bfdbfe 40%, #60a5fa 100%);
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .hero-media::after {
+    content: "";
+    position: absolute;
+    inset: 12%;
+    border-radius: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    pointer-events: none;
+  }
+
+  .hero-media svg {
+    width: 90%;
+    height: auto;
+    display: block;
+  }
+
+  .hero-picture {
+    display: block;
+    height: auto;
   }
 
   .actions {
@@ -228,8 +313,30 @@ const displayAreas = areasServed;
     margin: 0;
   }
 
+  @media (min-width: 960px) {
+    .hero {
+      grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+      align-items: center;
+    }
+
+    .hero-content {
+      text-align: left;
+    }
+
+    .actions,
+    .quick-links {
+      justify-content: flex-start;
+    }
+
+    .hero-media,
+    .hero-picture {
+      margin: 0;
+      justify-self: center;
+    }
+  }
+
   @media (max-width: 640px) {
-    .hero p {
+    .hero-content p {
       font-size: 1.05rem;
     }
   }


### PR DESCRIPTION
## Summary
- replace the home page hero image with an inline SVG fallback and keep the `<Picture />` usage as a commented example
- add ignores for generated image folders and author guidance for recreating local placeholders in `IMAGES.md`
- commit the generated Astro env type stub so type checking works without binary assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2dca397788326a6914ded3b552ef5