### PR TITLE
Generate PNG Open Graph images via sharp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Dependencies
+node_modules/
+
+# Astro build output
+.astro/
+dist/
+src/env.d.ts
+
+# Logs
+npm-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "lakeshore-outdoor-services",
       "version": "0.1.0",
+      "dependencies": {
+        "sharp": "^0.33.5"
+      },
       "devDependencies": {
         "@astrojs/sitemap": "^3.1.3",
         "astro": "^4.6.1"
@@ -2329,9 +2332,9 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
-      "optional": true,
+      "optional": false,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -2344,9 +2347,9 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
-      "optional": true,
+      "optional": false,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2358,17 +2361,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
-      "optional": true
+      "optional": false
     },
     "node_modules/color-string": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
-      "optional": true,
+      "optional": false,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -2468,9 +2471,9 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "dev": false,
       "license": "Apache-2.0",
-      "optional": true,
+      "optional": false,
       "engines": {
         "node": ">=8"
       }
@@ -3121,9 +3124,9 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
-      "optional": true
+      "optional": false
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -5112,7 +5115,7 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
+      "dev": false,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5125,10 +5128,10 @@
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
       "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-      "dev": true,
+      "dev": false,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
+      "optional": false,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.3",
@@ -5196,9 +5199,9 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
       "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "dev": true,
+      "dev": false,
       "license": "MIT",
-      "optional": true,
+      "optional": false,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build": "astro build",
     "preview": "astro preview"
   },
-  "dependencies": {},
+  "dependencies": {
+    "sharp": "^0.33.5"
+  },
   "devDependencies": {
     "@astrojs/sitemap": "^3.1.3",
     "astro": "^4.6.1"

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,0 +1,18 @@
+# Components
+
+## Open Graph image workflow
+
+The default Open Graph image is generated on-demand by the `/og/` endpoint (`src/pages/og/index.astro`). The handler builds an SVG layout with `createOgSvg` and rasterizes it to PNG pixels via `rasterizeSvgToPng`, which wraps [`sharp`](https://sharp.pixelplumbing.com/). Requests can override copy by providing `title`, `subtitle`, `tagline`, or `contact` query parameters. All responses are cached for a day with immutable caching headers.
+
+`SEO.astro` automatically points `og:image` and `twitter:image` to this endpoint when no custom `image` prop is provided, ensuring every page exposes a PNG asset sized `1200x630`.
+
+### Overriding with designer-provided assets
+
+If the design team supplies bespoke artwork:
+
+1. Export the final image as a 1200×630 PNG (or larger while maintaining that 1.91:1 aspect ratio).
+2. Add the file to `public/` (e.g., `public/og/services.png`).
+3. Pass its absolute URL to the `SEO` component: `<SEO image={new URL('/og/services.png', BUSINESS.site).toString()} {...props} />`.
+4. Optionally disable the generated art for that route by setting `image` wherever the page calls `<SEO />`.
+
+You can still keep the dynamic generator for other routes—the fallback only activates when `image` is undefined.

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -14,6 +14,8 @@ const siteUrl = BUSINESS.site;
 const url = canonical ?? new URL(Astro.url.pathname, siteUrl).toString();
 const brand = BUSINESS.name;
 const formattedTitle = title.includes(brand) ? title : `${title} | ${brand}`;
+const fallbackOgImage = new URL("/og/", siteUrl).toString();
+const ogImage = image ?? fallbackOgImage;
 ---
 <Fragment>
   <title>{formattedTitle}</title>
@@ -24,9 +26,12 @@ const formattedTitle = title.includes(brand) ? title : `${title} | ${brand}`;
   <meta property="og:description" content={description} />
   <meta property="og:url" content={url} />
   <meta property="og:site_name" content={BUSINESS.name} />
-  {image && <meta property="og:image" content={image} />}
-  <meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
+  <meta property="og:image" content={ogImage} />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content={formattedTitle} />
   <meta name="twitter:description" content={description} />
-  {image && <meta name="twitter:image" content={image} />}
+  <meta name="twitter:image" content={ogImage} />
 </Fragment>

--- a/src/pages/og/index.astro
+++ b/src/pages/og/index.astro
@@ -1,0 +1,32 @@
+---
+import { BUSINESS } from "../../data/business";
+import { formatPhoneForDisplay } from "../../utils/phone";
+import { createOgSvg, rasterizeSvgToPng } from "../../utils/og-image";
+
+export const prerender = false;
+
+const searchParams = Astro.url.searchParams;
+
+const title = searchParams.get("title")?.trim() || `${BUSINESS.name}`;
+const subtitle = searchParams.get("subtitle")?.trim() || "Snow & Ice Management for Chicago & the North Shore";
+const tagline = searchParams.get("tagline")?.trim() || "Plowing, salting, and sidewalk crews on call all winter";
+const contact = searchParams.get("contact")?.trim() || formatPhoneForDisplay(BUSINESS.phone);
+
+const svg = createOgSvg({
+  title,
+  subtitle,
+  tagline,
+  contact,
+  brand: BUSINESS.name,
+});
+
+const png = await rasterizeSvgToPng(svg);
+
+return new Response(png, {
+  headers: {
+    "Content-Type": "image/png",
+    "Content-Length": String(png.byteLength),
+    "Cache-Control": "public, max-age=86400, immutable",
+  },
+});
+---

--- a/src/utils/og-image.ts
+++ b/src/utils/og-image.ts
@@ -1,0 +1,171 @@
+import { BUSINESS } from "../data/business";
+
+export const OG_IMAGE_WIDTH = 1200;
+export const OG_IMAGE_HEIGHT = 630;
+
+export interface OgImageOptions {
+  title: string;
+  subtitle: string;
+  tagline: string;
+  contact: string;
+  brand?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface RasterizeOptions {
+  density?: number;
+}
+
+const escapeHtml = (value: string): string =>
+  value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return char;
+    }
+  });
+
+const wrapText = (value: string, maxChars = 28): string[] => {
+  const normalized = value
+    .split(/\r?\n/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  const lines: string[] = [];
+
+  for (const segment of normalized) {
+    const words = segment.split(/\s+/);
+    let current = "";
+
+    for (const word of words) {
+      if (!current.length) {
+        current = word;
+        continue;
+      }
+
+      const next = `${current} ${word}`;
+      if (next.length <= maxChars) {
+        current = next;
+      } else {
+        lines.push(current);
+        current = word;
+      }
+    }
+
+    if (current.length) {
+      lines.push(current);
+    }
+  }
+
+  return lines.length ? lines : [value.trim()];
+};
+
+const createTspans = (lines: string[], x: number, y: number, lineHeight: number): string => {
+  if (!lines.length) return "";
+
+  return lines
+    .map((line, index) => {
+      const position = index === 0 ? `x="${x}" y="${y}"` : `x="${x}" dy="${lineHeight}"`;
+      return `<tspan ${position}>${escapeHtml(line)}</tspan>`;
+    })
+    .join("");
+};
+
+const estimateLabelWidth = (label: string, fontSize: number, basePadding: number): number => {
+  const averageGlyphWidth = fontSize * 0.62;
+  return Math.round(label.length * averageGlyphWidth + basePadding);
+};
+
+export const createOgSvg = ({
+  title,
+  subtitle,
+  tagline,
+  contact,
+  brand = BUSINESS.name,
+  width = OG_IMAGE_WIDTH,
+  height = OG_IMAGE_HEIGHT,
+}: OgImageOptions): string => {
+  const paddedWidth = width;
+  const paddedHeight = height;
+  const padding = 80;
+
+  const brandLabel = brand.toUpperCase();
+  const brandWidth = Math.max(estimateLabelWidth(brandLabel, 24, 80), 320);
+
+  const titleLines = wrapText(title, 22);
+  const subtitleLines = wrapText(subtitle, 32);
+
+  const titleY = padding + 180;
+  const subtitleY = titleY + Math.max(titleLines.length, 1) * 78 + 32;
+  const taglineY = paddedHeight - padding * 1.35;
+
+  const contactLabel = escapeHtml(contact);
+  const taglineLabel = escapeHtml(tagline);
+
+  const titleTspans = createTspans(titleLines, padding, titleY, 78);
+  const subtitleTspans = createTspans(subtitleLines, padding, subtitleY, 54);
+
+  const contactBoxWidth = Math.max(estimateLabelWidth(contact, 28, 160), 320);
+  const contactX = padding;
+  const contactY = paddedHeight - padding - 20;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="${paddedWidth}" height="${paddedHeight}" viewBox="0 0 ${paddedWidth} ${paddedHeight}" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ogTitle">
+  <title id="ogTitle">${escapeHtml(title)}</title>
+  <desc>${escapeHtml(tagline)}</desc>
+  <defs>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0B172A" />
+      <stop offset="100%" stop-color="#11354A" />
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22D3EE" />
+      <stop offset="100%" stop-color="#38BDF8" />
+    </linearGradient>
+  </defs>
+  <rect width="${paddedWidth}" height="${paddedHeight}" fill="url(#bgGradient)" />
+  <rect x="${paddedWidth - 320}" y="${padding - 40}" width="260" height="260" rx="32" fill="#0F1F2D" opacity="0.45" />
+  <rect x="${padding - 24}" y="${padding + 36}" width="${paddedWidth - padding * 2 + 48}" height="${paddedHeight - padding * 2 - 24}" rx="48" fill="#0E2435" opacity="0.45" />
+  <path d="M${paddedWidth - 180} ${paddedHeight - 80} C${paddedWidth - 80} ${paddedHeight - 180} ${paddedWidth - 200} ${padding} ${paddedWidth - 60} ${padding}" stroke="url(#accentGradient)" stroke-width="6" stroke-linecap="round" opacity="0.45" />
+  <rect x="${padding - 4}" y="${padding - 4}" width="${brandWidth}" height="52" rx="18" fill="#134E4A" opacity="0.35" />
+  <text x="${padding + 16}" y="${padding + 30}" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="24" font-weight="600" letter-spacing="0.14em" fill="#A5F3FC">${escapeHtml(brandLabel)}</text>
+  <text font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="72" font-weight="700" fill="#F8FAFC" letter-spacing="0.01em">
+    ${titleTspans}
+  </text>
+  <text font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="44" font-weight="500" fill="#E0F2FE" opacity="0.92">
+    ${subtitleTspans}
+  </text>
+  <g>
+    <rect x="${contactX}" y="${contactY - 64}" width="${contactBoxWidth}" height="72" rx="24" fill="rgba(15, 118, 110, 0.9)" />
+    <text x="${contactX + 36}" y="${contactY - 20}" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="36" font-weight="600" fill="#ECFEFF">
+      ${contactLabel}
+    </text>
+  </g>
+  <text x="${padding}" y="${taglineY}" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="32" font-weight="400" fill="#BAE6FD" opacity="0.95">
+    ${taglineLabel}
+  </text>
+</svg>`;
+};
+
+export const rasterizeSvgToPng = async (svg: string, options: RasterizeOptions = {}): Promise<Buffer> => {
+  const { density = 260 } = options;
+  const { default: sharp } = await import("sharp");
+
+  return sharp(Buffer.from(svg), { density })
+    .png({
+      compressionLevel: 9,
+      adaptiveFiltering: true,
+      force: true,
+    })
+    .toBuffer();
+};


### PR DESCRIPTION
## Summary
- add a server-rendered `/og/` endpoint that converts the existing SVG layout to PNG bytes and allows query parameter overrides
- update the `SEO` component to default `og:image` and Twitter tags to the raster output and include PNG metadata
- document the new rasterization workflow for designers and ignore generated build artifacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2dca7cca48326b0524755431bfdeb