### PR TITLE
Update sitemap configuration to exclude utility pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,24 @@
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 
+const excludedPaths = new Set(['/og', '/thank-you', '/404']);
+
+const normalizePath = (pathname) => (pathname !== '/' ? pathname.replace(/\/$/, '') : pathname);
+
 export default defineConfig({
   site: 'https://lakeshoreoutdoor.com',
   output: 'static',
   integrations: [
-    sitemap({ entryLimit: 45000 })
+    sitemap({
+      entryLimit: 45000,
+      filter: (page) => {
+        const value = typeof page === 'string' ? page : page.url;
+        if (!value) return true;
+        const pathname = typeof value === 'string'
+          ? new URL(value, 'https://lakeshoreoutdoor.com').pathname
+          : value.pathname;
+        return !excludedPaths.has(normalizePath(pathname));
+      }
+    })
   ]
 });


### PR DESCRIPTION
## Summary
- configure the sitemap integration to filter out the /og, /thank-you, and /404 routes when generating entries

## Testing
- npx astro build

------
https://chatgpt.com/codex/tasks/task_e_68e2f38ca06c8326b61b72793a2339b5