### PR TITLE
Update repository gitignore ruleset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,41 @@
+# Dependencies
 node_modules/
+
+# Build output
+.astro/
+dist/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment files
+.env
+.env.local
+.env.development
+.env.production
+.env.test
+!.env.example
+
+# Generated assets
 src/assets/generated/
 public/img/
-.astro/
+
+# Binary images
+*.avif
+*.gif
+*.heic
+*.jpeg
+*.jpg
+*.png
+*.webp
+
+# Allow tracked public files
+!public/CNAME
+!public/robots.txt


### PR DESCRIPTION
## Summary
- replace the repository root .gitignore with a broader ruleset covering dependencies, build output, and generated assets
- ignore common binary image formats while continuing to track public/CNAME and public/robots.txt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f38a69648326a1529e945aed2fad