### PR TITLE
Add RemotePicture component backed by remote image manifest

### DIFF
--- a/IMAGES.md
+++ b/IMAGES.md
@@ -1,71 +1,26 @@
-# Images
+# Remote images
 
-The repository avoids committing binary image assets so the default clone stays lightweight and text-only. When you need to
-test Astro's `<Picture />` pipeline locally, generate temporary placeholders on your machine and keep them out of version
-control.
+The site intentionally keeps binary assets out of the repository. Production imagery is hosted on a CDN and described through a
+small manifest so Astro pages can reference them without shipping large files in git.
 
-## Hero placeholder workflow
+## Workflow
 
-The home page hero includes a commented example that expects a file at `src/assets/generated/hero-placeholder.png`. Follow the
-steps below to create (and later remove) that file as needed.
+1. **Prepare the asset locally.** Export or edit the image, then optimize it (e.g., with ImageOptim, Squoosh, or Sharp) so it is
+   web-ready.
+2. **Upload to the CDN.** Place the optimized file in the CDN bucket or media library that serves the site. Copy the final public
+   URL.
+3. **Add a manifest entry.** Update `src/data/images.remote.json` with an object that includes:
+   - `id`: Stable identifier (e.g., `"hero-crew"`).
+   - `src`: The CDN URL.
+   - `alt`: Human-readable alternative text.
+   - Optional metadata you expect to reuse such as `width`, `height`, `credit`, `creditUrl`, `srcset`, or `sizes`.
+4. **Consume the image in templates.** Import and render `<RemotePicture id="…" />` in Astro components or pages. The component
+   pulls manifest data via `getRemoteImage()` and renders an `<img>` with the configured attributes. Provide any optional HTML
+   attributes (class names, loading hints, etc.) as props.
 
-1. Create the working directory:
-   ```bash
-   mkdir -p src/assets/generated
-   ```
-2. Choose one of the following approaches to place a lightweight image in that directory:
-   - **Download a placeholder:**
-     ```bash
-     curl "https://dummyimage.com/1200x800/60a5fa/eff6ff.png&text=Snow+Crew" \
-       --output src/assets/generated/hero-placeholder.png
-     ```
-     This produces a ~50–70 KB PNG with a gradient background and text label that is sufficient for development.
-   - **Generate a gradient with Sharp:**
-     ```bash
-     npm install --save-dev sharp
-     node <<'NODE'
-     import sharp from "sharp";
+## Runtime helpers
 
-     const width = 1200;
-     const height = 800;
+- `getRemoteImage(id)` throws an error when an unknown identifier is requested, guiding you to add the missing entry.
+- `listRemoteImages()` returns the manifest array if you need to iterate over available assets (e.g., in a gallery).
 
-     const gradient = Buffer.from(
-       `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">\n` +
-         '<defs>\n' +
-         '  <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">\n' +
-         '    <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.75"/>\n' +
-         '    <stop offset="100%" stop-color="#1d4ed8" stop-opacity="0.9"/>\n' +
-         '  </linearGradient>\n' +
-         '</defs>\n' +
-         `<rect width="${width}" height="${height}" fill="url(#g)" rx="48"/>\n` +
-         '</svg>'
-     );
-
-     await sharp(gradient)
-       .png({ compressionLevel: 9 })
-       .toFile("src/assets/generated/hero-placeholder.png");
-     NODE
-     ```
-     Remove `sharp` from `devDependencies` after you finish if you installed it solely for generating placeholders.
-
-## Using the placeholder with `<Picture />`
-
-Once the image exists locally, uncomment or adapt the example in `src/pages/index.astro`:
-
-```astro
-import { Picture } from "astro:assets";
-
-<Picture
-  src={Astro.resolve("../assets/generated/hero-placeholder.png")}
-  widths={[480, 768, 1024]}
-  sizes="(max-width: 960px) 100vw, 520px"
-  formats={["avif", "webp", "png"]}
-  alt="Snow removal crew clearing a driveway"
-  class="hero-picture"
-/>
-```
-
-## Clean up before committing
-
-Delete any generated binaries when you're done or keep them ignored under `src/assets/generated/`. The `.gitignore` file is
-configured to skip that folder so placeholders never reach the repository.
+This flow keeps the repo lightweight, ensures consistent alt text, and centralizes CDN metadata in one place.

--- a/src/components/RemotePicture.astro
+++ b/src/components/RemotePicture.astro
@@ -1,0 +1,71 @@
+---
+import type { HTMLAttributes } from "astro/types";
+import { getRemoteImage } from "../data/images";
+
+interface Props extends HTMLAttributes<"img"> {
+  id: string;
+}
+
+const {
+  id,
+  alt: altProp,
+  src: srcProp,
+  srcset: srcsetProp,
+  sizes: sizesProp,
+  ...rest
+} = Astro.props as Props;
+
+if (!id) {
+  throw new Error("<RemotePicture /> requires an `id` prop to look up the remote image.");
+}
+
+if (altProp !== undefined) {
+  throw new Error("<RemotePicture /> derives alt text from the manifest. Remove the `alt` prop override.");
+}
+
+if (srcProp !== undefined) {
+  throw new Error("<RemotePicture /> manages the `src` attribute automatically. Remove the `src` prop override.");
+}
+
+if (srcsetProp !== undefined) {
+  throw new Error("<RemotePicture /> manages the `srcset` attribute. Configure variants in the manifest instead.");
+}
+
+if (sizesProp !== undefined) {
+  throw new Error("<RemotePicture /> manages the `sizes` attribute. Configure it in the manifest entry instead.");
+}
+
+const manifestEntry = getRemoteImage(id);
+const { src, alt, width, height, srcset, sizes } = manifestEntry;
+
+const missingFields: string[] = [];
+
+if (!src) missingFields.push("src");
+if (!alt) missingFields.push("alt");
+
+if (missingFields.length > 0) {
+  throw new Error(
+    `<RemotePicture /> manifest entry "${id}" is missing required field(s): ${missingFields.join(", ")}.`,
+  );
+}
+
+const attributes: Record<string, unknown> = {
+  src,
+  alt,
+  loading: "lazy",
+  decoding: "async",
+  ...rest,
+};
+
+if (width) attributes.width = width;
+if (height) attributes.height = height;
+
+if (srcset) {
+  attributes.srcset = Array.isArray(srcset) ? srcset.join(", ") : srcset;
+}
+
+if (sizes) {
+  attributes.sizes = sizes;
+}
+---
+<img {...attributes} />

--- a/src/data/images.remote.json
+++ b/src/data/images.remote.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "hero-crew",
+    "src": "https://images.unsplash.com/photo-1604472739642-0caa60fe0570?auto=format&fit=crop&w=1600&q=80",
+    "alt": "Snow removal crew clearing a residential driveway at night",
+    "width": 1600,
+    "height": 1067,
+    "credit": "Photo by Vladimir Fedotov on Unsplash",
+    "creditUrl": "https://unsplash.com/photos/person-shoveling-snow-during-nighttime-PkXp80Gkn6I"
+  }
+]

--- a/src/data/images.ts
+++ b/src/data/images.ts
@@ -1,0 +1,49 @@
+import manifest from "./images.remote.json";
+
+export interface RemoteImage {
+  id: string;
+  src: string;
+  alt: string;
+  width?: number;
+  height?: number;
+  credit?: string;
+  creditUrl?: string;
+  srcset?: string | string[];
+  sizes?: string;
+  [key: string]: unknown;
+}
+
+const manifestEntries = manifest as RemoteImage[];
+const manifestById = new Map<string, RemoteImage>();
+
+for (const entry of manifestEntries) {
+  if (!entry || typeof entry !== "object") {
+    throw new Error("Remote image manifest entries must be objects.");
+  }
+
+  if (!entry.id || typeof entry.id !== "string") {
+    throw new Error("Each remote image entry requires a string `id` field.");
+  }
+
+  if (manifestById.has(entry.id)) {
+    throw new Error(`Duplicate remote image id detected: "${entry.id}".`);
+  }
+
+  manifestById.set(entry.id, Object.freeze({ ...entry }));
+}
+
+export function getRemoteImage(id: string): RemoteImage {
+  const image = manifestById.get(id);
+
+  if (!image) {
+    throw new Error(
+      `Remote image with id "${id}" was not found. Add an entry to src/data/images.remote.json to use it.`,
+    );
+  }
+
+  return image;
+}
+
+export function listRemoteImages(): RemoteImage[] {
+  return Array.from(manifestById.values());
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Base from "../layouts/Base.astro";
 import SEO from "../components/SEO.astro";
 import JsonLd from "../components/JsonLd.astro";
+import RemotePicture from "../components/RemotePicture.astro";
 import { BUSINESS, phone_display, phone_e164 } from "../data/business";
 
 const title = `${BUSINESS.name} | Chicago snow removal crews`;
@@ -60,46 +61,8 @@ const displayAreas = areasServed;
         <a href="/locations/snow-removal-evanston/">Evanston crews</a>
       </div>
     </div>
-    <div class="hero-media" aria-hidden="true">
-      <!--
-        Example: replace this SVG with a locally generated asset when testing the responsive image pipeline.
-        <Picture
-          src={Astro.resolve("../assets/generated/hero-placeholder.png")}
-          widths={[480, 768, 1024]}
-          sizes="(max-width: 960px) 100vw, 520px"
-          formats={["avif", "webp", "png"]}
-          alt="Snow removal crew clearing a driveway"
-          class="hero-picture"
-        />
-      -->
-      <svg viewBox="0 0 320 220" role="presentation" focusable="false">
-        <defs>
-          <linearGradient id="heroGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.25" />
-            <stop offset="100%" stop-color="#1d4ed8" stop-opacity="0.65" />
-          </linearGradient>
-        </defs>
-        <rect width="320" height="220" rx="28" fill="url(#heroGradient)" />
-        <g fill="#f8fafc" opacity="0.9">
-          <circle cx="76" cy="72" r="28" />
-          <circle cx="122" cy="98" r="18" />
-          <circle cx="182" cy="70" r="22" />
-        </g>
-        <path
-          d="M32 160c32-28 64-28 96 0s64 28 96 0 64-28 96 0"
-          fill="none"
-          stroke="#dbeafe"
-          stroke-width="12"
-          stroke-linecap="round"
-        />
-        <path
-          d="M40 182c32-18 64-18 96 0s64 18 96 0 64-18 96 0"
-          fill="none"
-          stroke="#eff6ff"
-          stroke-width="10"
-          stroke-linecap="round"
-        />
-      </svg>
+    <div class="hero-media">
+      <RemotePicture id="hero-crew" class="hero-picture" loading="eager" />
     </div>
   </section>
   <section class="services">
@@ -183,7 +146,7 @@ const displayAreas = areasServed;
     aspect-ratio: 16 / 11;
     background: linear-gradient(135deg, #dbeafe 10%, #bfdbfe 40%, #60a5fa 100%);
     display: grid;
-    place-items: center;
+    place-items: stretch;
     overflow: hidden;
     position: relative;
   }
@@ -197,15 +160,11 @@ const displayAreas = areasServed;
     pointer-events: none;
   }
 
-  .hero-media svg {
-    width: 90%;
-    height: auto;
-    display: block;
-  }
-
   .hero-picture {
     display: block;
-    height: auto;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
 
   .actions {


### PR DESCRIPTION
## Summary
- add a JSON manifest for CDN-hosted imagery with reusable metadata
- expose helpers for fetching remote image data and render through a new RemotePicture component
- integrate the component into the home page hero and document the CDN-driven workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e576bd868883269ebc9f4f21f20589